### PR TITLE
Add queue_size for asynchronous publishing

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -42,9 +42,9 @@ import libnmea_navsat_driver.parser
 
 class RosNMEADriver(object):
     def __init__(self):
-        self.fix_pub = rospy.Publisher('fix', NavSatFix)
-        self.vel_pub = rospy.Publisher('vel', TwistStamped)
-        self.time_ref_pub = rospy.Publisher('time_reference', TimeReference)
+        self.fix_pub = rospy.Publisher('fix', NavSatFix, queue_size=1)
+        self.vel_pub = rospy.Publisher('vel', TwistStamped, queue_size=1)
+        self.time_ref_pub = rospy.Publisher('time_reference', TimeReference, queue_size=1)
 
         self.time_ref_source = rospy.get_param('~time_ref_source',
                 None)


### PR DESCRIPTION
rospy nags about this at startup of the node. Shouldn't be any reason we need synchronous, I don't think.

cf. http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers#rospy.Publisher_initialization
