### PR TITLE
Added a nmea_gpsd_driver

### DIFF
--- a/scripts/nmea_gpsd_driver
+++ b/scripts/nmea_gpsd_driver
@@ -1,0 +1,96 @@
+#! /usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Zac Witte
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the names of the authors nor the names of their
+#    affiliated organizations may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import socket
+import sys
+
+import rospy
+
+import libnmea_navsat_driver.driver
+
+if __name__ == '__main__':
+    rospy.init_node('nmea_gpsd_driver')
+
+    try:
+        local_hostname = rospy.get_param('~hostname', 'localhost')
+        local_port = rospy.get_param('~port', 2947)
+        buffer_size = rospy.get_param('~buffer_size', 4096)
+        timeout = rospy.get_param('~timeout', 5)
+    except KeyError as e:
+        rospy.logerr("Parameter %s not found" % e)
+        sys.exit(1)
+
+    frame_id = libnmea_navsat_driver.driver.RosNMEADriver.get_frame_id()
+
+    try:
+        # Create a socket
+        rospy.loginfo("Connecting to NMEA socket on %s:%s" % (local_hostname, local_port))
+        _socket = socket.create_connection((local_hostname, local_port))
+
+        # Set timeout
+        _socket.settimeout(timeout)
+        
+        watch_msg = "?WATCH="+'{"class":"WATCH","enable":true,"json":false,"nmea":true,"raw":2}'
+        _socket.sendall(watch_msg)
+    except socket.error, exc:
+        rospy.logerr("Caught exception socket.error : %s" % exc)
+        raise
+        sys.exit(1)
+
+    driver = libnmea_navsat_driver.driver.RosNMEADriver()
+
+    while not rospy.is_shutdown():
+        try:
+            data, remote_address = _socket.recvfrom(buffer_size)
+        except socket.timeout, exc:
+            rospy.logerr("GPSD socket timed out: %s" % exc)
+            continue
+        except socket.error, exc:
+            rospy.logerr("Caught exception socket.error : %s" % exc)
+            break
+
+        # strip the data
+        data_list = data.strip().split("\n")
+
+        for data in data_list:
+            if data[0] != '$': continue
+            
+            try:
+                driver.add_sentence(data, frame_id)
+            except ValueError as e:
+                rospy.logwarn("Value error, likely due to missing fields in the NMEA message. "
+                            "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
+                            "including a bag file with the NMEA sentences that caused it. NMEA String: %s" % (e, data))
+
+    _socket.close()  # Close socket

--- a/scripts/nmea_gpsd_driver
+++ b/scripts/nmea_gpsd_driver
@@ -55,17 +55,16 @@ if __name__ == '__main__':
 
     try:
         # Create a socket
-        rospy.loginfo("Connecting to NMEA socket on %s:%s" % (local_hostname, local_port))
+        rospy.loginfo("Connecting to GPSD server on %s:%s" % (local_hostname, local_port))
         _socket = socket.create_connection((local_hostname, local_port))
 
         # Set timeout
         _socket.settimeout(timeout)
-        
-        watch_msg = "?WATCH="+'{"class":"WATCH","enable":true,"json":false,"nmea":true,"raw":2}'
+
+        watch_msg = """?WATCH={"class":"WATCH","enable":true,"json":false,"nmea":true,"raw":2}"""
         _socket.sendall(watch_msg)
     except socket.error, exc:
         rospy.logerr("Caught exception socket.error : %s" % exc)
-        raise
         sys.exit(1)
 
     driver = libnmea_navsat_driver.driver.RosNMEADriver()

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -126,7 +126,7 @@ parse_maps = {
 
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
-    if not re.match('^\$GP.*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+    if not re.match('^\$(GP|GN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))
         return False


### PR DESCRIPTION
Based off of the nmea_socket_driver by @reinzor (pull request #16). This uses a TCP connection to a GPSD server, send the command to watch, and requests raw nmea sentences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ros-drivers/nmea_navsat_driver/18)
<!-- Reviewable:end -->
