### PR TITLE
Novatel OEM4 Support Fix

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -89,6 +89,10 @@ class RosNMEADriver(object):
                 current_fix.status.status = NavSatStatus.STATUS_SBAS_FIX
             elif gps_qual in (4, 5):
                 current_fix.status.status = NavSatStatus.STATUS_GBAS_FIX
+            elif gps_qual == 9:
+                # Support specifically for NOVATEL OEM4 recievers which report WAAS fix as 9
+                # http://www.novatel.com/support/known-solutions/which-novatel-position-types-correspond-to-the-gga-quality-indicator/
+                current_fix.status.status = NavSatStatus.STATUS_SBAS_FIX
             else:
                 current_fix.status.status = NavSatStatus.STATUS_NO_FIX
 


### PR DESCRIPTION
Updated driver to accept status of 9 which some novatel recievers report for a WAAS (SBAS) fix.

See http://www.novatel.com/support/known-solutions/which-novatel-position-types-correspond-to-the-gga-quality-indicator/
