### PR TITLE
Cleanup of CMakeLists, package.xml.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(nmea_navsat_driver)
 
-find_package(catkin REQUIRED COMPONENTS roslint)
+find_package(catkin REQUIRED)
 
 catkin_python_setup()
 catkin_package()
@@ -13,6 +13,8 @@ install(PROGRAMS
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-# Check package for pep8 style, add a test to fail on violations.
-roslint_python()
-roslint_add_test()
+if (CATKIN_ENABLE_TESTING)
+  find_package(roslint)
+  roslint_python()
+  roslint_add_test()
+endif()

--- a/package.xml
+++ b/package.xml
@@ -1,34 +1,29 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>nmea_navsat_driver</name>
   <version>0.5.0</version>
   <description>
-	Package to parse NMEA strings and publish a very simple GPS message. Does not require the GPSD deamon.
+    Package to parse NMEA strings and publish a very simple GPS message. Does not 
+    require or use the GPSD deamon.
   </description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <maintainer email="eric@ericperko.com">Eric Perko</maintainer>
 
-  <!-- One license tag required, multiple allowed, one license per tag -->
   <license>BSD</license>
 
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <url type="website">http://ros.org/wiki/nmea_navsat_driver</url>
 
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
   <author email="eric@ericperko.com">Eric Perko</author>
   <author>Steven Martin</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roslint</build_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>python-serial</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>nmea_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>python-serial</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>nmea_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 
+  <test_depend>roslint</test_depend>
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- This is a pure Python package, so mark it architecture independent -->


### PR DESCRIPTION
By going to package format 2, we can make roslint a test depend rather than build depend.