### PR TITLE
Removed automatic prefixing of forward slash to frame_id.

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -177,14 +177,4 @@ class RosNMEADriver(object):
     @staticmethod
     def get_frame_id():
         frame_id = rospy.get_param('~frame_id', 'gps')
-        if frame_id[0] != "/":
-            """Add the TF prefix"""
-            prefix = ""
-            prefix_param = rospy.search_param('tf_prefix')
-            if prefix_param:
-                prefix = rospy.get_param(prefix_param)
-                if prefix[0] != "/":
-                    prefix = "/%s" % prefix
-            return "%s/%s" % (prefix, frame_id)
-        else:
-            return frame_id
+        return frame_id

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -177,14 +177,11 @@ class RosNMEADriver(object):
     @staticmethod
     def get_frame_id():
         frame_id = rospy.get_param('~frame_id', 'gps')
-        if frame_id[0] != "/":
-            """Add the TF prefix"""
-            prefix = ""
-            prefix_param = rospy.search_param('tf_prefix')
-            if prefix_param:
-                prefix = rospy.get_param(prefix_param)
-                if prefix[0] != "/":
-                    prefix = "/%s" % prefix
+        """Add the TF prefix"""
+        prefix = ""
+        prefix_param = rospy.search_param('tf_prefix')
+        if prefix_param:
+            prefix = rospy.get_param(prefix_param)
             return "%s/%s" % (prefix, frame_id)
         else:
             return frame_id

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -177,4 +177,14 @@ class RosNMEADriver(object):
     @staticmethod
     def get_frame_id():
         frame_id = rospy.get_param('~frame_id', 'gps')
-        return frame_id
+        if frame_id[0] != "/":
+            """Add the TF prefix"""
+            prefix = ""
+            prefix_param = rospy.search_param('tf_prefix')
+            if prefix_param:
+                prefix = rospy.get_param(prefix_param)
+                if prefix[0] != "/":
+                    prefix = "/%s" % prefix
+            return "%s/%s" % (prefix, frame_id)
+        else:
+            return frame_id


### PR DESCRIPTION
Removed the automatic prefixing of forward slash, but to be consistent with the current default behavior,
the default frame_id has been set to `/gps` with the prepended forward slash.