### PR TITLE
Slash is deprecated in tf2. Hence compulsion removed.

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -177,14 +177,5 @@ class RosNMEADriver(object):
     @staticmethod
     def get_frame_id():
         frame_id = rospy.get_param('~frame_id', 'gps')
-        if frame_id[0] != "/":
-            """Add the TF prefix"""
-            prefix = ""
-            prefix_param = rospy.search_param('tf_prefix')
-            if prefix_param:
-                prefix = rospy.get_param(prefix_param)
-                if prefix[0] != "/":
-                    prefix = "/%s" % prefix
-            return "%s/%s" % (prefix, frame_id)
-        else:
-            return frame_id
+        """ Slash is deprecated in tf2. """
+        return frame_id


### PR DESCRIPTION
" /gps " frame ID gives warnings when used with latest tf. Hence code of driver was modified to update this in jade-devel.