### PR TITLE
try to avoid binary content after serial read

### DIFF
--- a/scripts/nmea_serial_driver
+++ b/scripts/nmea_serial_driver
@@ -55,6 +55,7 @@ if __name__ == '__main__':
             while not rospy.is_shutdown():
                 data = GPS.readline().strip()
                 try:
+                    data = data[data.index('$'):] # remove all stuff before the first $. See https://github.com/ros-drivers/nmea_navsat_driver/issues/45#issuecomment-420073153
                     driver.add_sentence(data, frame_id)
                 except ValueError as e:
                     rospy.logwarn("Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)


### PR DESCRIPTION
See https://github.com/ros-drivers/nmea_navsat_driver/issues/45#issuecomment-420073153

This might help for GPS devices with binary content over serial.
This does not affect any current working case as if `$` is the first character it will do nothing.

I put it in serial_driver in order to not affect others drivers.