### PR TITLE
Remove automatic prefixing of forward slash to frame_id. (#33)

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -259,14 +259,11 @@ class RosNMEADriver(object):
     @staticmethod
     def get_frame_id():
         frame_id = rospy.get_param('~frame_id', 'gps')
-        if frame_id[0] != "/":
-            """Add the TF prefix"""
-            prefix = ""
-            prefix_param = rospy.search_param('tf_prefix')
-            if prefix_param:
-                prefix = rospy.get_param(prefix_param)
-                if prefix[0] != "/":
-                    prefix = "/%s" % prefix
+        """Add the TF prefix"""
+        prefix = ""
+        prefix_param = rospy.search_param('tf_prefix')
+        if prefix_param:
+            prefix = rospy.get_param(prefix_param)
             return "%s/%s" % (prefix, frame_id)
         else:
             return frame_id


### PR DESCRIPTION
Remove the automatic prefixing of forward slash, but to be consistent with the current default behavior, the default frame_id has been set to /gps with the prepended forward slash.

This is a duplicate of #33, which was merged to jade-devel, to port that change forward to master.