### PR TITLE
Add support for IMU aided GPS systems (#30)

### DIFF
--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -133,6 +133,10 @@ parse_maps = {
         ],
     "HDT": [
         ("heading", safe_float, 1),
+        ],
+    "VTG":[
+        ("true_course", safe_float,1),
+        ("speed", convert_knots_to_mps,5)
         ]
     }
 
@@ -140,7 +144,7 @@ parse_maps = {
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
 
-    if not re.match('(^\$GP|^\$GN|^\$GL).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+    if not re.match('(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))
         return False


### PR DESCRIPTION
* Adds support for IMU aided GPS systems like the Applanix POS/MV, whose NMEA strings typically begin '$IN'. (e.g. $INGGA).
* Adds support for VTG messages, which contain Course Over Ground and Speed Made Good. These are useful when not using RMC messages and you don't have a heading sensor.

This is a duplicate of #30, which was merged to jade-devel, to port that change forward to master.