### PR TITLE
Removed roslint as build depend.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <name>nmea_navsat_driver</name>
   <version>0.5.0</version>
   <description>
-    Package to parse NMEA strings and publish a very simple GPS message. Does not 
+    Package to parse NMEA strings and publish a very simple GPS message. Does not
     require or use the GPSD deamon.
   </description>
 
@@ -17,7 +17,6 @@
   <author>Steven Martin</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roslint</build_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>python-serial</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>


### PR DESCRIPTION
Re-added here: https://github.com/ros-drivers/nmea_navsat_driver/pull/25.