### PR TITLE
Fix Dependencies in Ros2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,12 +17,13 @@
     <author email="eric@ericperko.com">Eric Perko</author>
     <author>Steven Martin</author>
 
-    <exec_depend>rclpy</exec_depend>
-    <exec_depend>python-serial</exec_depend>
     <exec_depend>geometry_msgs</exec_depend>
     <exec_depend>nmea_msgs</exec_depend>
+    <exec_depend>rclpy</exec_depend>
     <exec_depend>sensor_msgs</exec_depend>
-    <exec_depend>transforms3d</exec_depend>
+    <exec_depend>python3-numpy</exec_depend>
+    <exec_depend>python-serial</exec_depend>
+    <exec_depend>python-transforms3d-pip</exec_depend>
 
     <test_depend>python3-pytest</test_depend>
 


### PR DESCRIPTION
Fix for #65. To test:

```bash
docker run -it osrf/ros:crystal-desktop 
apt update && apt install -y python3-colcon-common-extensions
(cd /usr/bin && ln -s pip3 pip)
rosdep init
rosdep update
mkdir -p workspace/src
cd workspace/src
git clone https://github.com/evenator/nmea_navsat_driver.git -b ros2-fix-dependencies
git clone https://github.com/ros-drivers/nmea_msgs.git -b ros2
cd ..
rosdep install -i --from-paths src --rosdistro crystal
```