### PR TITLE
Fix PEP8 Violations

### DIFF
--- a/scripts/nmea_serial_driver
+++ b/scripts/nmea_serial_driver
@@ -43,8 +43,8 @@ import sys
 if __name__ == '__main__':
     rospy.init_node('nmea_serial_driver')
 
-    serial_port = rospy.get_param('~port','/dev/ttyUSB0')
-    serial_baud = rospy.get_param('~baud',4800)
+    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
+    serial_baud = rospy.get_param('~baud', 4800)
     frame_id = libnmea_navsat_driver.driver.RosNMEADriver.get_frame_id()
 
     try:
@@ -57,9 +57,15 @@ if __name__ == '__main__':
                 try:
                     driver.add_sentence(data, frame_id)
                 except ValueError as e:
-                    rospy.logwarn("Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
+                    rospy.logwarn(
+                        "Value error, likely due to missing fields in the NMEA message. "
+                        "Error was: %s. Please report this issue at "
+                        "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
+                        "sentences that caused it." %
+                        e)
 
         except (rospy.ROSInterruptException, serial.serialutil.SerialException):
-            GPS.close() #Close GPS serial port
+            GPS.close()  # Close GPS serial port
     except serial.SerialException as ex:
-        rospy.logfatal("Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))
+        rospy.logfatal(
+            "Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))

--- a/scripts/nmea_socket_driver
+++ b/scripts/nmea_socket_driver
@@ -55,7 +55,8 @@ if __name__ == '__main__':
 
     driver = libnmea_navsat_driver.driver.RosNMEADriver()
 
-    # Connection-loop: connect and keep receiving. If receiving fails, reconnect
+    # Connection-loop: connect and keep receiving. If receiving fails,
+    # reconnect
     while not rospy.is_shutdown():
         try:
             # Create a socket
@@ -66,11 +67,14 @@ if __name__ == '__main__':
 
             # Set timeout
             socket_.settimeout(timeout)
-        except socket.error, exc:
-            rospy.logerr("Caught exception socket.error when setting up socket: %s" % exc)
+        except socket.error as exc:
+            rospy.logerr(
+                "Caught exception socket.error when setting up socket: %s" %
+                exc)
             sys.exit(1)
 
-        # recv-loop: When we're connected, keep receiving stuff until that fails
+        # recv-loop: When we're connected, keep receiving stuff until that
+        # fails
         while not rospy.is_shutdown():
             try:
                 data, remote_address = socket_.recvfrom(buffer_size)
@@ -83,14 +87,19 @@ if __name__ == '__main__':
                     try:
                         driver.add_sentence(data, frame_id)
                     except ValueError as e:
-                        rospy.logwarn("Value error, likely due to missing fields in the NMEA message. "
-                                    "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
-                                    "including a bag file with the NMEA sentences that caused it." % e)
+                        rospy.logwarn(
+                            "Value error, likely due to missing fields in the NMEA message. "
+                            "Error was: %s. Please report this issue at "
+                            "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
+                            "sentences that caused it." %
+                            e)
 
-            except socket.error, exc:
-                rospy.logerr("Caught exception socket.error during recvfrom: %s" % exc)
+            except socket.error as exc:
+                rospy.logerr(
+                    "Caught exception socket.error during recvfrom: %s" % exc)
                 socket_.close()
-                # This will break out of the recv-loop so we start another iteration of the connection-loop
+                # This will break out of the recv-loop so we start another
+                # iteration of the connection-loop
                 break
 
         socket_.close()  # Close socket

--- a/scripts/nmea_topic_driver
+++ b/scripts/nmea_topic_driver
@@ -38,11 +38,20 @@ from nmea_msgs.msg import Sentence
 
 import libnmea_navsat_driver.driver
 
+
 def nmea_sentence_callback(nmea_sentence, driver):
     try:
-        driver.add_sentence(nmea_sentence.sentence, frame_id=nmea_sentence.header.frame_id, timestamp=nmea_sentence.header.stamp)
+        driver.add_sentence(
+            nmea_sentence.sentence,
+            frame_id=nmea_sentence.header.frame_id,
+            timestamp=nmea_sentence.header.stamp)
     except ValueError as e:
-        rospy.logwarn("Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
+        rospy.logwarn(
+            "Value error, likely due to missing fields in the NMEA message. "
+            "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
+            "including a bag file with the NMEA sentences that caused it." %
+            e)
+
 
 if __name__ == '__main__':
     rospy.init_node('nmea_topic_driver')
@@ -50,6 +59,6 @@ if __name__ == '__main__':
     driver = libnmea_navsat_driver.driver.RosNMEADriver()
 
     rospy.Subscriber("nmea_sentence", Sentence, nmea_sentence_callback,
-            driver)
+                     driver)
 
     rospy.spin()

--- a/scripts/nmea_topic_serial_reader
+++ b/scripts/nmea_topic_serial_reader
@@ -44,8 +44,8 @@ if __name__ == '__main__':
 
     nmea_pub = rospy.Publisher("nmea_sentence", Sentence, queue_size=1)
 
-    serial_port = rospy.get_param('~port','/dev/ttyUSB0')
-    serial_baud = rospy.get_param('~baud',4800)
+    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
+    serial_baud = rospy.get_param('~baud', 4800)
 
     # Get the frame_id
     frame_id = RosNMEADriver.get_frame_id()
@@ -57,10 +57,10 @@ if __name__ == '__main__':
 
             sentence = Sentence()
             sentence.header.stamp = rospy.get_rostime()
-	    sentence.header.frame_id = frame_id
+            sentence.header.frame_id = frame_id
             sentence.sentence = data
 
             nmea_pub.publish(sentence)
 
     except rospy.ROSInterruptException:
-        GPS.close() #Close GPS serial port
+        GPS.close()  # Close GPS serial port

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[pycodestyle]
+max-line-length = 120
+statistics = True
+show-pep8 = True

--- a/src/libnmea_navsat_driver/checksum_utils.py
+++ b/src/libnmea_navsat_driver/checksum_utils.py
@@ -35,11 +35,12 @@
 def check_nmea_checksum(nmea_sentence):
     split_sentence = nmea_sentence.split('*')
     if len(split_sentence) != 2:
-        #No checksum bytes were found... improperly formatted/incomplete NMEA data?
+        # No checksum bytes were found... improperly formatted/incomplete NMEA
+        # data?
         return False
     transmitted_checksum = split_sentence[1].strip()
 
-    #Remove the $ at the front
+    # Remove the $ at the front
     data_to_checksum = split_sentence[0][1:]
     checksum = 0
     for c in data_to_checksum:

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -47,8 +47,10 @@ class RosNMEADriver(object):
     def __init__(self):
         self.fix_pub = rospy.Publisher('fix', NavSatFix, queue_size=1)
         self.vel_pub = rospy.Publisher('vel', TwistStamped, queue_size=1)
-        self.heading_pub = rospy.Publisher('heading', QuaternionStamped, queue_size=1)
-        self.time_ref_pub = rospy.Publisher('time_reference', TimeReference, queue_size=1)
+        self.heading_pub = rospy.Publisher(
+            'heading', QuaternionStamped, queue_size=1)
+        self.time_ref_pub = rospy.Publisher(
+            'time_reference', TimeReference, queue_size=1)
 
         self.time_ref_source = rospy.get_param('~time_ref_source', None)
         self.use_RMC = rospy.get_param('~useRMC', False)
@@ -71,49 +73,49 @@ class RosNMEADriver(object):
         each entry containing a tuple consisting of a default estimated
         position error, a NavSatStatus value, and a NavSatFix covariance value."""
         self.gps_qualities = {
-          # Unknown
-          -1: [
-              self.default_epe_quality0,
-              NavSatStatus.STATUS_NO_FIX,
-              NavSatFix.COVARIANCE_TYPE_UNKNOWN
-              ],
-          # Invalid
-          0: [
-              self.default_epe_quality0,
-              NavSatStatus.STATUS_NO_FIX,
-              NavSatFix.COVARIANCE_TYPE_UNKNOWN
-              ],
-          # SPS
-          1: [
-              self.default_epe_quality1,
-              NavSatStatus.STATUS_FIX,
-              NavSatFix.COVARIANCE_TYPE_APPROXIMATED
-              ],
-          # DGPS
-          2: [
-              self.default_epe_quality2,
-              NavSatStatus.STATUS_SBAS_FIX,
-              NavSatFix.COVARIANCE_TYPE_APPROXIMATED
-              ],
-          # RTK Fix
-          4: [
-              self.default_epe_quality4,
-              NavSatStatus.STATUS_GBAS_FIX,
-              NavSatFix.COVARIANCE_TYPE_APPROXIMATED
-              ],
-          # RTK Float
-          5: [
-              self.default_epe_quality5,
-              NavSatStatus.STATUS_GBAS_FIX,
-              NavSatFix.COVARIANCE_TYPE_APPROXIMATED
-              ],
-          # WAAS
-          9: [
-              self.default_epe_quality9,
-              NavSatStatus.STATUS_GBAS_FIX,
-              NavSatFix.COVARIANCE_TYPE_APPROXIMATED
-              ]
-          }
+            # Unknown
+            -1: [
+                self.default_epe_quality0,
+                NavSatStatus.STATUS_NO_FIX,
+                NavSatFix.COVARIANCE_TYPE_UNKNOWN
+            ],
+            # Invalid
+            0: [
+                self.default_epe_quality0,
+                NavSatStatus.STATUS_NO_FIX,
+                NavSatFix.COVARIANCE_TYPE_UNKNOWN
+            ],
+            # SPS
+            1: [
+                self.default_epe_quality1,
+                NavSatStatus.STATUS_FIX,
+                NavSatFix.COVARIANCE_TYPE_APPROXIMATED
+            ],
+            # DGPS
+            2: [
+                self.default_epe_quality2,
+                NavSatStatus.STATUS_SBAS_FIX,
+                NavSatFix.COVARIANCE_TYPE_APPROXIMATED
+            ],
+            # RTK Fix
+            4: [
+                self.default_epe_quality4,
+                NavSatStatus.STATUS_GBAS_FIX,
+                NavSatFix.COVARIANCE_TYPE_APPROXIMATED
+            ],
+            # RTK Float
+            5: [
+                self.default_epe_quality5,
+                NavSatStatus.STATUS_GBAS_FIX,
+                NavSatFix.COVARIANCE_TYPE_APPROXIMATED
+            ],
+            # WAAS
+            9: [
+                self.default_epe_quality9,
+                NavSatStatus.STATUS_GBAS_FIX,
+                NavSatFix.COVARIANCE_TYPE_APPROXIMATED
+            ]
+        }
 
     # Returns True if we successfully did something with the passed in
     # nmea_string
@@ -123,9 +125,12 @@ class RosNMEADriver(object):
                           "Sentence was: %s" % repr(nmea_string))
             return False
 
-        parsed_sentence = libnmea_navsat_driver.parser.parse_nmea_sentence(nmea_string)
+        parsed_sentence = libnmea_navsat_driver.parser.parse_nmea_sentence(
+            nmea_string)
         if not parsed_sentence:
-            rospy.logdebug("Failed to parse NMEA sentence. Sentence was: %s" % nmea_string)
+            rospy.logdebug(
+                "Failed to parse NMEA sentence. Sentence was: %s" %
+                nmea_string)
             return False
 
         if timestamp:
@@ -150,11 +155,11 @@ class RosNMEADriver(object):
             data = parsed_sentence['GGA']
             fix_type = data['fix_type']
             if not (fix_type in self.gps_qualities):
-              fix_type = -1
+                fix_type = -1
             gps_qual = self.gps_qualities[fix_type]
-            default_epe = gps_qual[0];
+            default_epe = gps_qual[0]
             current_fix.status.status = gps_qual[1]
-            current_fix.position_covariance_type = gps_qual[2];
+            current_fix.position_covariance_type = gps_qual[2]
 
             if gps_qual > 0:
                 self.valid_fix = True
@@ -177,7 +182,8 @@ class RosNMEADriver(object):
             altitude = data['altitude'] + data['mean_sea_level']
             current_fix.altitude = altitude
 
-            # use default epe std_dev unless we've received a GST sentence with epes
+            # use default epe std_dev unless we've received a GST sentence with
+            # epes
             if not self.using_receiver_epe or math.isnan(self.lon_std_dev):
                 self.lon_std_dev = default_epe
             if not self.using_receiver_epe or math.isnan(self.lat_std_dev):
@@ -188,27 +194,30 @@ class RosNMEADriver(object):
             hdop = data['hdop']
             current_fix.position_covariance[0] = (hdop * self.lon_std_dev) ** 2
             current_fix.position_covariance[4] = (hdop * self.lat_std_dev) ** 2
-            current_fix.position_covariance[8] = (2 * hdop * self.alt_std_dev) ** 2  # FIXME
+            current_fix.position_covariance[8] = (
+                2 * hdop * self.alt_std_dev) ** 2  # FIXME
 
             self.fix_pub.publish(current_fix)
 
             if not math.isnan(data['utc_time']):
-                current_time_ref.time_ref = rospy.Time.from_sec(data['utc_time'])
+                current_time_ref.time_ref = rospy.Time.from_sec(
+                    data['utc_time'])
                 self.last_valid_fix_time = current_time_ref
                 self.time_ref_pub.publish(current_time_ref)
 
         elif not self.use_RMC and 'VTG' in parsed_sentence:
             data = parsed_sentence['VTG']
 
-            # Only report VTG data when you've received a valid GGA fix as well.
+            # Only report VTG data when you've received a valid GGA fix as
+            # well.
             if self.valid_fix:
                 current_vel = TwistStamped()
                 current_vel.header.stamp = current_time
                 current_vel.header.frame_id = frame_id
                 current_vel.twist.linear.x = data['speed'] * \
-                                             math.sin(data['true_course'])
+                    math.sin(data['true_course'])
                 current_vel.twist.linear.y = data['speed'] * \
-                                             math.cos(data['true_course'])
+                    math.cos(data['true_course'])
                 self.vel_pub.publish(current_vel)
 
         elif 'RMC' in parsed_sentence:
@@ -240,10 +249,12 @@ class RosNMEADriver(object):
                 self.fix_pub.publish(current_fix)
 
                 if not math.isnan(data['utc_time']):
-                    current_time_ref.time_ref = rospy.Time.from_sec(data['utc_time'])
+                    current_time_ref.time_ref = rospy.Time.from_sec(
+                        data['utc_time'])
                     self.time_ref_pub.publish(current_time_ref)
 
-            # Publish velocity from RMC regardless, since GGA doesn't provide it.
+            # Publish velocity from RMC regardless, since GGA doesn't provide
+            # it.
             if data['fix_valid']:
                 current_vel = TwistStamped()
                 current_vel.header.stamp = current_time

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -95,6 +95,7 @@ def convert_knots_to_mps(knots):
 def convert_deg_to_rads(degs):
     return math.radians(safe_float(degs))
 
+
 """Format for this dictionary is a sentence identifier (e.g. "GGA") as the key, with a
 list of tuples where each tuple is a field name, conversion function and index
 into the split sentence"""
@@ -110,7 +111,7 @@ parse_maps = {
         ("hdop", safe_float, 8),
         ("num_satellites", safe_int, 7),
         ("utc_time", convert_time, 1),
-        ],
+    ],
     "RMC": [
         ("utc_time", convert_time, 1),
         ("fix_valid", convert_status_flag, 2),
@@ -120,7 +121,7 @@ parse_maps = {
         ("longitude_direction", str, 6),
         ("speed", convert_knots_to_mps, 7),
         ("true_course", convert_deg_to_rads, 8),
-        ],
+    ],
     "GST": [
         ("utc_time", convert_time, 1),
         ("ranges_std_dev", safe_float, 2),
@@ -130,30 +131,32 @@ parse_maps = {
         ("lat_std_dev", safe_float, 6),
         ("lon_std_dev", safe_float, 7),
         ("alt_std_dev", safe_float, 8),
-        ],
+    ],
     "HDT": [
         ("heading", safe_float, 1),
-        ],
-    "VTG":[
-        ("true_course", safe_float,1),
-        ("speed", convert_knots_to_mps,5)
-        ]
-    }
+    ],
+    "VTG": [
+        ("true_course", safe_float, 1),
+        ("speed", convert_knots_to_mps, 5)
+    ]
+}
 
 
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
 
-    if not re.match('(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
-        logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
-                     % repr(nmea_sentence))
+    if not re.match(
+            r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+        logger.debug(
+            "Regex didn't match, sentence not valid NMEA? Sentence was: %s" %
+            repr(nmea_sentence))
         return False
     fields = [field.strip(',') for field in nmea_sentence.split(',')]
 
     # Ignore the $ and talker ID portions (e.g. GP)
     sentence_type = fields[0][3:]
 
-    if not sentence_type in parse_maps:
+    if sentence_type not in parse_maps:
         logger.debug("Sentence type %s not in parse map, ignoring."
                      % repr(sentence_type))
         return False


### PR DESCRIPTION
- Fix PEP8 violations with a combination of `autopep8` and manual tweaks.
- Add a `setup.cfg` file with configuration for `pycodestyle`

`pycodestyle scripts/* src setup.py` now passes.