### PR TITLE
Fix PEP8 Violations in ROS 2

### DIFF
--- a/scripts/nmea_serial_driver.py
+++ b/scripts/nmea_serial_driver.py
@@ -59,7 +59,9 @@ def main(args=None):
                     driver.add_sentence(data, frame_id)
                 except ValueError as e:
                     driver.get_logger().warn(
-                        "Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
+                        "Value error, likely due to missing fields in the NMEA message. Error was: %s. "
+                        "Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file "
+                        "with the NMEA sentences that caused it." % e)
 
         except Exception as e:
             driver.get_logger().error("Ros error: {0}".format(e))

--- a/scripts/nmea_socket_driver.py
+++ b/scripts/nmea_socket_driver.py
@@ -83,9 +83,10 @@ def main(args=None):
                     try:
                         driver.add_sentence(data, frame_id)
                     except ValueError as e:
-                        rclpy.get_logger().warn("Value error, likely due to missing fields in the NMEA message. "
-                                                "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
-                                                "including a bag file with the NMEA sentences that caused it." % e)
+                        rclpy.get_logger().warn(
+                            "Value error, likely due to missing fields in the NMEA message. "
+                            "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
+                            "including a bag file with the NMEA sentences that caused it." % e)
 
             except socket.error as exc:
                 driver.get_logger().error("Caught exception socket.error during recvfrom: %s" % exc)

--- a/scripts/nmea_topic_driver.py
+++ b/scripts/nmea_topic_driver.py
@@ -45,7 +45,9 @@ def nmea_sentence_callback(nmea_sentence, driver):
                             timestamp=nmea_sentence.header.stamp)
     except ValueError as e:
         rclpy.get_logger().warn(
-            "Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
+            "Value error, likely due to missing fields in the NMEA message. Error was: %s. "
+            "Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with "
+            "the NMEA sentences that caused it." % e)
 
 
 def main(args=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[develop]
-script-dir=$base/lib/nmea_navsat_driver
-[install]
-install-scripts=$base/lib/nmea_navsat_driver
+[pycodestyle]
+max-line-length = 120
+statistics = True
+show-pep8 = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
+[develop]
+script-dir=$base/lib/nmea_navsat_driver
+
+[install]
+install-scripts=$base/lib/nmea_navsat_driver
+
 [pycodestyle]
 max-line-length = 120
 statistics = True

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -147,8 +147,7 @@ class Ros2NMEADriver(Node):
             current_time_ref.source = frame_id
 
         if not self.use_RMC and 'GGA' in parsed_sentence:
-            current_fix.position_covariance_type = \
-                NavSatFix.COVARIANCE_TYPE_APPROXIMATED
+            current_fix.position_covariance_type = NavSatFix.COVARIANCE_TYPE_APPROXIMATED
 
             data = parsed_sentence['GGA']
             fix_type = data['fix_type']
@@ -206,10 +205,8 @@ class Ros2NMEADriver(Node):
                 current_vel = TwistStamped()
                 current_vel.header.stamp = current_time
                 current_vel.header.frame_id = frame_id
-                current_vel.twist.linear.x = data['speed'] * \
-                                             math.sin(data['true_course'])
-                current_vel.twist.linear.y = data['speed'] * \
-                                             math.cos(data['true_course'])
+                current_vel.twist.linear.x = data['speed'] * math.sin(data['true_course'])
+                current_vel.twist.linear.y = data['speed'] * math.cos(data['true_course'])
                 self.vel_pub.publish(current_vel)
 
         elif 'RMC' in parsed_sentence:
@@ -249,10 +246,8 @@ class Ros2NMEADriver(Node):
                 current_vel = TwistStamped()
                 current_vel.header.stamp = current_time
                 current_vel.header.frame_id = frame_id
-                current_vel.twist.linear.x = data['speed'] * \
-                                             math.sin(data['true_course'])
-                current_vel.twist.linear.y = data['speed'] * \
-                                             math.cos(data['true_course'])
+                current_vel.twist.linear.x = data['speed'] * math.sin(data['true_course'])
+                current_vel.twist.linear.y = data['speed'] * math.cos(data['true_course'])
                 self.vel_pub.publish(current_vel)
         elif 'GST' in parsed_sentence:
             data = parsed_sentence['GST']

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -146,7 +146,7 @@ parse_maps = {
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
 
-    if not re.match('(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+    if not re.match(r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))
         return False
@@ -155,7 +155,7 @@ def parse_nmea_sentence(nmea_sentence):
     # Ignore the $ and talker ID portions (e.g. GP)
     sentence_type = fields[0][3:]
 
-    if not sentence_type in parse_maps:
+    if sentence_type not in parse_maps:
         logger.debug("Sentence type %s not in parse map, ignoring."
                      % repr(sentence_type))
         return False


### PR DESCRIPTION
- Fix PEP8 violations with a combination of `autopep8` and manual tweaks.
- Update the `setup.cfg` file with configuration for `pycodestyle`.

`pycodestyle scripts/* src setup.py` now passes.