### PR TITLE
Fix nmea_topic_serial_reader name

### DIFF
--- a/scripts/nmea_topic_serial_reader.py
+++ b/scripts/nmea_topic_serial_reader.py
@@ -55,14 +55,18 @@ def main(args=None):
 
     try:
         GPS = serial.Serial(port=serial_port, baudrate=serial_baud, timeout=2)
-        while rclpy.ok():
-            data = GPS.readline().strip()
+        try:
+            while rclpy.ok():
+                data = GPS.readline().strip()
 
-            sentence = Sentence()
-            sentence.header.stamp = driver.get_clock().now().to_msg()
-            sentence.header.frame_id = frame_id
-            sentence.sentence = data
-            nmea_pub.publish(sentence)
+                sentence = Sentence()
+                sentence.header.stamp = driver.get_clock().now().to_msg()
+                sentence.header.frame_id = frame_id
+                sentence.sentence = data
+                nmea_pub.publish(sentence)
 
-    except rclpy.ROSInterruptException:
-        GPS.close()  # Close GPS serial port
+        except Exception as e:
+            driver.get_logger().error("Ros error: {0}".format(e))
+            GPS.close()  # Close GPS serial port
+    except serial.SerialException as ex:
+        driver.get_logger().fatal("Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(
         'console_scripts': ['nmea_serial_driver = scripts.nmea_serial_driver:main',
                             'nmea_socket_driver = scripts.nmea_socket_driver:main',
                             'nmea_topic_driver = scripts.nmea_topic_driver:main',
-                            'nmea_topic_serial_driver = scripts.nmea_topic_serial_driver:main'],
+                            'nmea_topic_serial_reader = scripts.nmea_topic_serial_reader:main'],
     }
 )


### PR DESCRIPTION
- Fix #72 (`no module named scripts.nmea_topic_serial_driver`)
- Fix exception handling in nmea_topic_serial_reader  (`'rclpy' has no attribute 'ROSInterruptException'`)

I've updated the exception handling to match the serial driver node. It's catch-all handling, which isn't ideal, but it's an improvement over trying to catch an exception that doesn't exist.