### PR TITLE
ROS 2: Remove scripts directory in favor of a nodes subpackage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,11 @@ SHARE_DIR = os.path.join("share", PACKAGE_NAME)
 setup(
     name=PACKAGE_NAME,
     version='0.5.1',
-    packages=["scripts", "libnmea_navsat_driver"],
+    packages=["libnmea_navsat_driver", "libnmea_navsat_driver.nodes"],
     data_files=[
         (os.path.join(SHARE_DIR, "launch"), glob(os.path.join("launch", "*.launch.py"))),
         (os.path.join(SHARE_DIR, "config"), glob(os.path.join("config", "*.yaml")))],
-    package_dir={'': 'src',
-                 "scripts": "scripts"},
+    package_dir={'': 'src',},
     py_modules=[],
     zip_safe=True,
     install_requires=['setuptools',
@@ -27,9 +26,9 @@ setup(
     description='Package to parse NMEA strings and publish a very simple GPS message.',
     license='BSD',
     entry_points={
-        'console_scripts': ['nmea_serial_driver = scripts.nmea_serial_driver:main',
-                            'nmea_socket_driver = scripts.nmea_socket_driver:main',
-                            'nmea_topic_driver = scripts.nmea_topic_driver:main',
-                            'nmea_topic_serial_reader = scripts.nmea_topic_serial_reader:main'],
+        'console_scripts': ['nmea_serial_driver = libnmea_navsat_driver.nodes.nmea_serial_driver:main',
+                            'nmea_socket_driver = libnmea_navsat_driver.nodes.nmea_socket_driver:main',
+                            'nmea_topic_driver = libnmea_navsat_driver.nodes.nmea_topic_driver:main',
+                            'nmea_topic_serial_reader = libnmea_navsat_driver.nodes.nmea_topic_serial_reader:main'],
     }
 )

--- a/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2016, Rein Appeldoorn
@@ -95,7 +93,3 @@ def main(args=None):
                 break
 
         socket_.close()  # Close socket
-
-
-if __name__ == '__main__':
-    main()

--- a/src/libnmea_navsat_driver/nodes/nmea_topic_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_driver.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2013, Eric Perko
@@ -32,43 +30,33 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import serial
 
+from nmea_msgs.msg import Sentence
 import rclpy
 
 from libnmea_navsat_driver.driver import Ros2NMEADriver
+
+
+def nmea_sentence_callback(nmea_sentence, driver):
+    try:
+        driver.add_sentence(nmea_sentence.sentence, frame_id=nmea_sentence.header.frame_id,
+                            timestamp=nmea_sentence.header.stamp)
+    except ValueError as e:
+        rclpy.get_logger().warn(
+            "Value error, likely due to missing fields in the NMEA message. Error was: %s. "
+            "Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with "
+            "the NMEA sentences that caused it." % e)
 
 
 def main(args=None):
     rclpy.init(args=args)
 
     driver = Ros2NMEADriver()
-    frame_id = driver.get_frame_id()
+    driver.get_frame_id()
 
-    serial_port = driver.get_parameter('port').value or '/dev/ttyUSB0'
-    serial_baud = driver.get_parameter('baud').value or 4800
+    driver.create_subscription(
+        Sentence, 'nmea_sentence', nmea_sentence_callback, driver)
 
-    try:
-        GPS = serial.Serial(port=serial_port, baudrate=serial_baud, timeout=2)
-        try:
-            while rclpy.ok():
-                data = GPS.readline().strip()
-                try:
-                    if isinstance(data, bytes):
-                        data = data.decode("utf-8")
-                    driver.add_sentence(data, frame_id)
-                except ValueError as e:
-                    driver.get_logger().warn(
-                        "Value error, likely due to missing fields in the NMEA message. Error was: %s. "
-                        "Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file "
-                        "with the NMEA sentences that caused it." % e)
+    rclpy.spin(node)
 
-        except Exception as e:
-            driver.get_logger().error("Ros error: {0}".format(e))
-            GPS.close()  # Close GPS serial port
-    except serial.SerialException as ex:
-        driver.get_logger().fatal("Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))
-
-
-if __name__ == '__main__':
-    main()
+    rclpy.shutdown()


### PR DESCRIPTION
Since these modules will no longer be called as scripts in ROS 2, move them to a nodes subpackage, and remove the option to call them as executables.

Addresses #75 for ROS 2.