### PR TITLE
Handle different line endings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Change log for nmea_navsat_driver package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add support for IMU aided GPS systems like the Applanix POS/MV, whose NMEA strings typically begin '$IN'. (e.g. $INGGA). Add support for VTG messages, which contain Course Over Ground and Speed Made Good. These are useful when not using RMC messages and you don't have a heading sensor. (`#30 <https://github.com/ros-drivers/nmea_navsat_driver/issues/30>`_/`#58 <https://github.com/ros-drivers/nmea_navsat_driver/issues/58>`_)
+* Add a NMEA socket driver node, which is like the existing serial driver node, but instead of attaching to a TTY handle from a serial port, it listens to a UDP port for NMEA sentences. (`#32 <https://github.com/ros-drivers/nmea_navsat_driver/issues/32>`_)
+* Add code to handle serial exception to allow node to exit cleanly (`#52 <https://github.com/ros-drivers/nmea_navsat_driver/issues/52>`_)
+* Cleanup CMakeLists, package.xml; using package format 2. (`#28 <https://github.com/ros-drivers/nmea_navsat_driver/issues/28>`_)
+* Update maintainer to Ed Venator (`#38 <https://github.com/ros-drivers/nmea_navsat_driver/issues/38>`_)
+* Add GLONASS support
+* Updated driver to accept status of 9 which some novatel recievers report for a WAAS (SBAS) fix.
+  See http://www.novatel.com/support/known-solutions/which-novatel-position-types-correspond-to-the-gga-quality-indicator/
+* Contributors: Ed Venator, Edward Venator, Eric Perko, Loy, Mike Purvis, Patrick Barone, Timo Röhling, Vikrant Shah
+
 0.5.0 (2015-04-23)
 ------------------
 * Release to Jade.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Change log for nmea_navsat_driver package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.5.1 (2018-12-30)
+------------------
 * Add support for IMU aided GPS systems like the Applanix POS/MV, whose NMEA strings typically begin '$IN'. (e.g. $INGGA). Add support for VTG messages, which contain Course Over Ground and Speed Made Good. These are useful when not using RMC messages and you don't have a heading sensor. (`#30 <https://github.com/ros-drivers/nmea_navsat_driver/issues/30>`_/`#58 <https://github.com/ros-drivers/nmea_navsat_driver/issues/58>`_)
 * Add a NMEA socket driver node, which is like the existing serial driver node, but instead of attaching to a TTY handle from a serial port, it listens to a UDP port for NMEA sentences. (`#32 <https://github.com/ros-drivers/nmea_navsat_driver/issues/32>`_)
 * Add code to handle serial exception to allow node to exit cleanly (`#52 <https://github.com/ros-drivers/nmea_navsat_driver/issues/52>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ catkin_package()
 
 install(PROGRAMS
    scripts/nmea_serial_driver
+   scripts/nmea_socket_driver
    scripts/nmea_topic_driver
    scripts/nmea_topic_serial_reader
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>nmea_navsat_driver</name>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
   <description>
     Package to parse NMEA strings and publish a very simple GPS message. Does not 
     require or use the GPSD deamon.

--- a/scripts/nmea_serial_driver
+++ b/scripts/nmea_serial_driver
@@ -38,6 +38,8 @@ import rospy
 
 import libnmea_navsat_driver.driver
 
+import sys
+
 if __name__ == '__main__':
     rospy.init_node('nmea_serial_driver')
 
@@ -47,13 +49,17 @@ if __name__ == '__main__':
 
     try:
         GPS = serial.Serial(port=serial_port, baudrate=serial_baud, timeout=2)
-        driver = libnmea_navsat_driver.driver.RosNMEADriver()
-        while not rospy.is_shutdown():
-            data = GPS.readline().strip()
-            try:
-                driver.add_sentence(data, frame_id)
-            except ValueError as e:
-                rospy.logwarn("Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
 
-    except rospy.ROSInterruptException:
-        GPS.close() #Close GPS serial port
+        try:
+            driver = libnmea_navsat_driver.driver.RosNMEADriver()
+            while not rospy.is_shutdown():
+                data = GPS.readline().strip()
+                try:
+                    driver.add_sentence(data, frame_id)
+                except ValueError as e:
+                    rospy.logwarn("Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
+
+        except (rospy.ROSInterruptException, serial.serialutil.SerialException):
+            GPS.close() #Close GPS serial port
+    except serial.SerialException as ex:
+        rospy.logfatal("Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))

--- a/scripts/nmea_socket_driver
+++ b/scripts/nmea_socket_driver
@@ -1,0 +1,96 @@
+#! /usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Rein Appeldoorn
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the names of the authors nor the names of their
+#    affiliated organizations may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import socket
+import sys
+
+import rospy
+
+import libnmea_navsat_driver.driver
+
+if __name__ == '__main__':
+    rospy.init_node('nmea_socket_driver')
+
+    try:
+        local_ip = rospy.get_param('~ip', '0.0.0.0')
+        local_port = rospy.get_param('~port', 10110)
+        buffer_size = rospy.get_param('~buffer_size', 4096)
+        timeout = rospy.get_param('~timeout_sec', 2)
+    except KeyError as e:
+        rospy.logerr("Parameter %s not found" % e)
+        sys.exit(1)
+
+    frame_id = libnmea_navsat_driver.driver.RosNMEADriver.get_frame_id()
+
+    driver = libnmea_navsat_driver.driver.RosNMEADriver()
+
+    # Connection-loop: connect and keep receiving. If receiving fails, reconnect
+    while not rospy.is_shutdown():
+        try:
+            # Create a socket
+            socket_ = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+            # Bind the socket to the port
+            socket_.bind((local_ip, local_port))
+
+            # Set timeout
+            socket_.settimeout(timeout)
+        except socket.error, exc:
+            rospy.logerr("Caught exception socket.error when setting up socket: %s" % exc)
+            sys.exit(1)
+
+        # recv-loop: When we're connected, keep receiving stuff until that fails
+        while not rospy.is_shutdown():
+            try:
+                data, remote_address = socket_.recvfrom(buffer_size)
+
+                # strip the data
+                data_list = data.strip().split("\n")
+
+                for data in data_list:
+
+                    try:
+                        driver.add_sentence(data, frame_id)
+                    except ValueError as e:
+                        rospy.logwarn("Value error, likely due to missing fields in the NMEA message. "
+                                    "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
+                                    "including a bag file with the NMEA sentences that caused it." % e)
+
+            except socket.error, exc:
+                rospy.logerr("Caught exception socket.error during recvfrom: %s" % exc)
+                socket_.close()
+                # This will break out of the recv-loop so we start another iteration of the connection-loop
+                break
+
+        socket_.close()  # Close socket

--- a/scripts/nmea_socket_driver
+++ b/scripts/nmea_socket_driver
@@ -32,6 +32,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import re
 import socket
 import sys
 
@@ -73,13 +74,14 @@ if __name__ == '__main__':
         # recv-loop: When we're connected, keep receiving stuff until that fails
         while not rospy.is_shutdown():
             try:
-                data, remote_address = socket_.recvfrom(buffer_size)
+                data = socket_.recv(buffer_size)
 
                 # strip the data
-                data_list = data.strip().split("\n")
+                data_list = [ line.strip() for line in re.split(r'[\r\n]+', data) ]
+                if not data_list[-1]:
+                    del data_list[-1]
 
                 for data in data_list:
-
                     try:
                         driver.add_sentence(data, frame_id)
                     except ValueError as e:
@@ -88,7 +90,7 @@ if __name__ == '__main__':
                                     "including a bag file with the NMEA sentences that caused it." % e)
 
             except socket.error, exc:
-                rospy.logerr("Caught exception socket.error during recvfrom: %s" % exc)
+                rospy.logerr("Caught exception socket.error during recv: %s" % exc)
                 socket_.close()
                 # This will break out of the recv-loop so we start another iteration of the connection-loop
                 break

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -49,6 +49,7 @@ class RosNMEADriver(object):
 
         self.time_ref_source = rospy.get_param('~time_ref_source', None)
         self.use_RMC = rospy.get_param('~useRMC', False)
+        self.valid_fix = False
 
     # Returns True if we successfully did something with the passed in
     # nmea_string
@@ -96,6 +97,11 @@ class RosNMEADriver(object):
             else:
                 current_fix.status.status = NavSatStatus.STATUS_NO_FIX
 
+            if gps_qual > 0:
+                self.valid_fix = True
+            else:
+                self.valid_fix = False
+
             current_fix.status.service = NavSatStatus.SERVICE_GPS
 
             current_fix.header.stamp = current_time
@@ -125,7 +131,22 @@ class RosNMEADriver(object):
 
             if not math.isnan(data['utc_time']):
                 current_time_ref.time_ref = rospy.Time.from_sec(data['utc_time'])
+                self.last_valid_fix_time = current_time_ref
                 self.time_ref_pub.publish(current_time_ref)
+
+        elif not self.use_RMC and 'VTG' in parsed_sentence:
+            data = parsed_sentence['VTG']
+
+            # Only report VTG data when you've received a valid GGA fix as well.
+            if self.valid_fix:
+                current_vel = TwistStamped()
+                current_vel.header.stamp = current_time
+                current_vel.header.frame_id = frame_id
+                current_vel.twist.linear.x = data['speed'] * \
+                                             math.sin(data['true_course'])
+                current_vel.twist.linear.y = data['speed'] * \
+                                             math.cos(data['true_course'])
+                self.vel_pub.publish(current_vel)
 
         elif 'RMC' in parsed_sentence:
             data = parsed_sentence['RMC']

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -120,6 +120,23 @@ parse_maps = {
         ("longitude_direction", str, 6),
         ("speed", convert_knots_to_mps, 7),
         ("true_course", convert_deg_to_rads, 8),
+        ],
+    "GST": [
+        ("utc_time", convert_time, 1),
+        ("ranges_std_dev", safe_float, 2),
+        ("semi_major_ellipse_std_dev", safe_float, 3),
+        ("semi_minor_ellipse_std_dev", safe_float, 4),
+        ("semi_major_orientation", safe_float, 5),
+        ("lat_std_dev", safe_float, 6),
+        ("lon_std_dev", safe_float, 7),
+        ("alt_std_dev", safe_float, 8),
+        ],
+    "HDT": [
+        ("heading", safe_float, 1),
+        ],
+    "VTG":[
+        ("true_course", safe_float,1),
+        ("speed", convert_knots_to_mps,5)
         ]
     }
 
@@ -127,7 +144,7 @@ parse_maps = {
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
 
-    if not re.match('(^\$GP|^\$GN|^\$GL).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+    if not re.match('(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))
         return False

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -126,6 +126,7 @@ parse_maps = {
 
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
+
     if not re.match('(^\$GP|^\$GN|^\$GL).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))


### PR DESCRIPTION
This changes the behavior of the socket driver to split incoming messages on different line endings including CR (`\r`), LF (`\n`) and CRLF (`\r\n`). Fixes #89.