### PR TITLE
Backport Recent Changes to Melodic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ install(PROGRAMS
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+install(DIRECTORY launch/
+   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+   FILES_MATCHING PATTERN "*.launch"
+)
+
 if (CATKIN_ENABLE_TESTING)
   find_package(roslint)
   roslint_python()

--- a/launch/nmea_serial_driver.launch
+++ b/launch/nmea_serial_driver.launch
@@ -1,0 +1,19 @@
+<launch>
+
+  <!-- A simple launch file for the nmea_serial_driver node. -->
+
+  <arg name="port" default="/dev/ttyUSB0" />
+  <arg name="baud" default="4800" />
+  <arg name="frame_id" default="gps" />
+  <arg name="time_ref_source" default="gps" />
+  <arg name="useRMC" default="False" />
+
+  <node name="nmea_serial_driver_node" pkg="nmea_navsat_driver" type="nmea_serial_driver" output="screen">
+    <param name="port" value="$(arg port)"/>
+    <param name="baud" value="$(arg baud)" />
+    <param name="frame_id" value="$(arg frame_id)" />
+    <param name="time_ref_source" value="$(arg time_ref_source)" />
+    <param name="useRMC" value="$(arg useRMC)" />
+  </node>
+
+</launch>

--- a/launch/nmea_serial_driver.launch
+++ b/launch/nmea_serial_driver.launch
@@ -5,6 +5,7 @@
   <arg name="port" default="/dev/ttyUSB0" />
   <arg name="baud" default="4800" />
   <arg name="frame_id" default="gps" />
+  <arg name="use_GNSS_time" default="False" />
   <arg name="time_ref_source" default="gps" />
   <arg name="useRMC" default="False" />
 
@@ -12,6 +13,7 @@
     <param name="port" value="$(arg port)"/>
     <param name="baud" value="$(arg baud)" />
     <param name="frame_id" value="$(arg frame_id)" />
+    <param name="use_GNSS_time" value="$(arg use_GNSS_time)" />
     <param name="time_ref_source" value="$(arg time_ref_source)" />
     <param name="useRMC" value="$(arg useRMC)" />
   </node>

--- a/launch/nmea_socket_driver.launch
+++ b/launch/nmea_socket_driver.launch
@@ -1,0 +1,21 @@
+<launch>
+
+  <!-- A simple launch file for the nmea_serial_driver node. -->
+
+  <arg name="ip" default="0.0.0.0" />
+  <arg name="port" default="10110" />
+  <arg name="frame_id" default="gps" />
+  <arg name="use_GNSS_time" default="False" />
+  <arg name="time_ref_source" default="gps" />
+  <arg name="useRMC" default="False" />
+
+  <node name="nmea_socket_driver_node" pkg="nmea_navsat_driver" type="nmea_socket_driver" output="screen">
+    <param name="ip" value="$(arg ip)" />
+    <param name="port" value="$(arg port)" />
+    <param name="frame_id" value="$(arg frame_id)" />
+    <param name="use_GNSS_time" value="$(arg use_GNSS_time)" />
+    <param name="time_ref_source" value="$(arg time_ref_source)" />
+    <param name="useRMC" value="$(arg useRMC)" />
+  </node>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <name>nmea_navsat_driver</name>
   <version>0.5.1</version>
   <description>
-    Package to parse NMEA strings and publish a very simple GPS message. Does not 
+    Package to parse NMEA strings and publish a very simple GPS message. Does not
     require or use the GPSD deamon.
   </description>
 

--- a/scripts/nmea_serial_driver
+++ b/scripts/nmea_serial_driver
@@ -2,7 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2013, Eric Perko
+# Copyright (c) 2019, Ed Venator <evenator@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,40 +32,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import serial
+import libnmea_navsat_driver.nodes.nmea_serial_driver
 
-import rospy
 
-import libnmea_navsat_driver.driver
-
-import sys
-
-if __name__ == '__main__':
-    rospy.init_node('nmea_serial_driver')
-
-    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
-    serial_baud = rospy.get_param('~baud', 4800)
-    frame_id = libnmea_navsat_driver.driver.RosNMEADriver.get_frame_id()
-
-    try:
-        GPS = serial.Serial(port=serial_port, baudrate=serial_baud, timeout=2)
-
-        try:
-            driver = libnmea_navsat_driver.driver.RosNMEADriver()
-            while not rospy.is_shutdown():
-                data = GPS.readline().strip()
-                try:
-                    driver.add_sentence(data, frame_id)
-                except ValueError as e:
-                    rospy.logwarn(
-                        "Value error, likely due to missing fields in the NMEA message. "
-                        "Error was: %s. Please report this issue at "
-                        "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
-                        "sentences that caused it." %
-                        e)
-
-        except (rospy.ROSInterruptException, serial.serialutil.SerialException):
-            GPS.close()  # Close GPS serial port
-    except serial.SerialException as ex:
-        rospy.logfatal(
-            "Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))
+libnmea_navsat_driver.nodes.nmea_serial_driver.main()

--- a/scripts/nmea_serial_driver
+++ b/scripts/nmea_serial_driver
@@ -43,8 +43,8 @@ import sys
 if __name__ == '__main__':
     rospy.init_node('nmea_serial_driver')
 
-    serial_port = rospy.get_param('~port','/dev/ttyUSB0')
-    serial_baud = rospy.get_param('~baud',4800)
+    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
+    serial_baud = rospy.get_param('~baud', 4800)
     frame_id = libnmea_navsat_driver.driver.RosNMEADriver.get_frame_id()
 
     try:
@@ -57,9 +57,15 @@ if __name__ == '__main__':
                 try:
                     driver.add_sentence(data, frame_id)
                 except ValueError as e:
-                    rospy.logwarn("Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
+                    rospy.logwarn(
+                        "Value error, likely due to missing fields in the NMEA message. "
+                        "Error was: %s. Please report this issue at "
+                        "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
+                        "sentences that caused it." %
+                        e)
 
         except (rospy.ROSInterruptException, serial.serialutil.SerialException):
-            GPS.close() #Close GPS serial port
+            GPS.close()  # Close GPS serial port
     except serial.SerialException as ex:
-        rospy.logfatal("Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))
+        rospy.logfatal(
+            "Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))

--- a/scripts/nmea_socket_driver
+++ b/scripts/nmea_socket_driver
@@ -55,7 +55,8 @@ if __name__ == '__main__':
 
     driver = libnmea_navsat_driver.driver.RosNMEADriver()
 
-    # Connection-loop: connect and keep receiving. If receiving fails, reconnect
+    # Connection-loop: connect and keep receiving. If receiving fails,
+    # reconnect
     while not rospy.is_shutdown():
         try:
             # Create a socket
@@ -66,11 +67,14 @@ if __name__ == '__main__':
 
             # Set timeout
             socket_.settimeout(timeout)
-        except socket.error, exc:
-            rospy.logerr("Caught exception socket.error when setting up socket: %s" % exc)
+        except socket.error as exc:
+            rospy.logerr(
+                "Caught exception socket.error when setting up socket: %s" %
+                exc)
             sys.exit(1)
 
-        # recv-loop: When we're connected, keep receiving stuff until that fails
+        # recv-loop: When we're connected, keep receiving stuff until that
+        # fails
         while not rospy.is_shutdown():
             try:
                 data, remote_address = socket_.recvfrom(buffer_size)
@@ -83,14 +87,19 @@ if __name__ == '__main__':
                     try:
                         driver.add_sentence(data, frame_id)
                     except ValueError as e:
-                        rospy.logwarn("Value error, likely due to missing fields in the NMEA message. "
-                                    "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
-                                    "including a bag file with the NMEA sentences that caused it." % e)
+                        rospy.logwarn(
+                            "Value error, likely due to missing fields in the NMEA message. "
+                            "Error was: %s. Please report this issue at "
+                            "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
+                            "sentences that caused it." %
+                            e)
 
-            except socket.error, exc:
-                rospy.logerr("Caught exception socket.error during recvfrom: %s" % exc)
+            except socket.error as exc:
+                rospy.logerr(
+                    "Caught exception socket.error during recvfrom: %s" % exc)
                 socket_.close()
-                # This will break out of the recv-loop so we start another iteration of the connection-loop
+                # This will break out of the recv-loop so we start another
+                # iteration of the connection-loop
                 break
 
         socket_.close()  # Close socket

--- a/scripts/nmea_topic_driver
+++ b/scripts/nmea_topic_driver
@@ -2,7 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2013, Eric Perko
+# Copyright (c) 2019, Ed Venator <evenator@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,33 +32,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import rospy
-
-from nmea_msgs.msg import Sentence
-
-import libnmea_navsat_driver.driver
+import libnmea_navsat_driver.nodes.nmea_topic_driver
 
 
-def nmea_sentence_callback(nmea_sentence, driver):
-    try:
-        driver.add_sentence(
-            nmea_sentence.sentence,
-            frame_id=nmea_sentence.header.frame_id,
-            timestamp=nmea_sentence.header.stamp)
-    except ValueError as e:
-        rospy.logwarn(
-            "Value error, likely due to missing fields in the NMEA message. "
-            "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
-            "including a bag file with the NMEA sentences that caused it." %
-            e)
-
-
-if __name__ == '__main__':
-    rospy.init_node('nmea_topic_driver')
-
-    driver = libnmea_navsat_driver.driver.RosNMEADriver()
-
-    rospy.Subscriber("nmea_sentence", Sentence, nmea_sentence_callback,
-                     driver)
-
-    rospy.spin()
+libnmea_navsat_driver.nodes.nmea_topic_driver.main()

--- a/scripts/nmea_topic_driver
+++ b/scripts/nmea_topic_driver
@@ -38,11 +38,20 @@ from nmea_msgs.msg import Sentence
 
 import libnmea_navsat_driver.driver
 
+
 def nmea_sentence_callback(nmea_sentence, driver):
     try:
-        driver.add_sentence(nmea_sentence.sentence, frame_id=nmea_sentence.header.frame_id, timestamp=nmea_sentence.header.stamp)
+        driver.add_sentence(
+            nmea_sentence.sentence,
+            frame_id=nmea_sentence.header.frame_id,
+            timestamp=nmea_sentence.header.stamp)
     except ValueError as e:
-        rospy.logwarn("Value error, likely due to missing fields in the NMEA message. Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA sentences that caused it." % e)
+        rospy.logwarn(
+            "Value error, likely due to missing fields in the NMEA message. "
+            "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
+            "including a bag file with the NMEA sentences that caused it." %
+            e)
+
 
 if __name__ == '__main__':
     rospy.init_node('nmea_topic_driver')
@@ -50,6 +59,6 @@ if __name__ == '__main__':
     driver = libnmea_navsat_driver.driver.RosNMEADriver()
 
     rospy.Subscriber("nmea_sentence", Sentence, nmea_sentence_callback,
-            driver)
+                     driver)
 
     rospy.spin()

--- a/scripts/nmea_topic_serial_reader
+++ b/scripts/nmea_topic_serial_reader
@@ -2,7 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2013, Eric Perko
+# Copyright (c) 2019, Ed Venator <evenator@gmail.com>
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,35 +32,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import serial
+import libnmea_navsat_driver.nodes.nmea_topic_serial_reader
 
-import rospy
 
-from nmea_msgs.msg import Sentence
-from libnmea_navsat_driver.driver import RosNMEADriver
-
-if __name__ == '__main__':
-    rospy.init_node('nmea_topic_serial_reader')
-
-    nmea_pub = rospy.Publisher("nmea_sentence", Sentence)
-
-    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
-    serial_baud = rospy.get_param('~baud', 4800)
-
-    # Get the frame_id
-    frame_id = RosNMEADriver.get_frame_id()
-
-    try:
-        GPS = serial.Serial(port=serial_port, baudrate=serial_baud, timeout=2)
-        while not rospy.is_shutdown():
-            data = GPS.readline().strip()
-
-            sentence = Sentence()
-            sentence.header.stamp = rospy.get_rostime()
-            sentence.header.frame_id = frame_id
-            sentence.sentence = data
-
-            nmea_pub.publish(sentence)
-
-    except rospy.ROSInterruptException:
-        GPS.close()  # Close GPS serial port
+libnmea_navsat_driver.nodes.nmea_topic_serial_reader.main()

--- a/scripts/nmea_topic_serial_reader
+++ b/scripts/nmea_topic_serial_reader
@@ -44,8 +44,8 @@ if __name__ == '__main__':
 
     nmea_pub = rospy.Publisher("nmea_sentence", Sentence)
 
-    serial_port = rospy.get_param('~port','/dev/ttyUSB0')
-    serial_baud = rospy.get_param('~baud',4800)
+    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
+    serial_baud = rospy.get_param('~baud', 4800)
 
     # Get the frame_id
     frame_id = RosNMEADriver.get_frame_id()
@@ -57,10 +57,10 @@ if __name__ == '__main__':
 
             sentence = Sentence()
             sentence.header.stamp = rospy.get_rostime()
-	    sentence.header.frame_id = frame_id
+            sentence.header.frame_id = frame_id
             sentence.sentence = data
 
             nmea_pub.publish(sentence)
 
     except rospy.ROSInterruptException:
-        GPS.close() #Close GPS serial port
+        GPS.close()  # Close GPS serial port

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[pycodestyle]
+max-line-length = 120
+statistics = True
+show-pep8 = True

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['libnmea_navsat_driver'],
+    packages=['libnmea_navsat_driver', 'libnmea_navsat_driver.nodes'],
     package_dir={'': 'src'}
 )
 

--- a/src/libnmea_navsat_driver/__init__.py
+++ b/src/libnmea_navsat_driver/__init__.py
@@ -1,0 +1,1 @@
+"""ROS nodes and supporting python code for ROS nmea_navsat_driver package."""

--- a/src/libnmea_navsat_driver/checksum_utils.py
+++ b/src/libnmea_navsat_driver/checksum_utils.py
@@ -35,11 +35,12 @@
 def check_nmea_checksum(nmea_sentence):
     split_sentence = nmea_sentence.split('*')
     if len(split_sentence) != 2:
-        #No checksum bytes were found... improperly formatted/incomplete NMEA data?
+        # No checksum bytes were found... improperly formatted/incomplete NMEA
+        # data?
         return False
     transmitted_checksum = split_sentence[1].strip()
 
-    #Remove the $ at the front
+    # Remove the $ at the front
     data_to_checksum = split_sentence[0][1:]
     checksum = 0
     for c in data_to_checksum:

--- a/src/libnmea_navsat_driver/checksum_utils.py
+++ b/src/libnmea_navsat_driver/checksum_utils.py
@@ -30,13 +30,20 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Utilities for calculating and checking NMEA checksums."""
 
-# Check the NMEA sentence checksum. Return True if passes and False if failed
+
 def check_nmea_checksum(nmea_sentence):
+    """Calculate and compare the checksum of a NMEA string.
+
+    Args:
+        nmea_sentence (str): The NMEA sentence to check.
+
+    Return True if the calculated checksum of the sentence matches the one provided.
+    """
     split_sentence = nmea_sentence.split('*')
     if len(split_sentence) != 2:
-        # No checksum bytes were found... improperly formatted/incomplete NMEA
-        # data?
+        # No checksum bytes were found... improperly formatted/incomplete NMEA data?
         return False
     transmitted_checksum = split_sentence[1].strip()
 

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -45,7 +45,8 @@ class RosNMEADriver(object):
     def __init__(self):
         self.fix_pub = rospy.Publisher('fix', NavSatFix, queue_size=1)
         self.vel_pub = rospy.Publisher('vel', TwistStamped, queue_size=1)
-        self.time_ref_pub = rospy.Publisher('time_reference', TimeReference, queue_size=1)
+        self.time_ref_pub = rospy.Publisher(
+            'time_reference', TimeReference, queue_size=1)
 
         self.time_ref_source = rospy.get_param('~time_ref_source', None)
         self.use_RMC = rospy.get_param('~useRMC', False)
@@ -59,9 +60,12 @@ class RosNMEADriver(object):
                           "Sentence was: %s" % repr(nmea_string))
             return False
 
-        parsed_sentence = libnmea_navsat_driver.parser.parse_nmea_sentence(nmea_string)
+        parsed_sentence = libnmea_navsat_driver.parser.parse_nmea_sentence(
+            nmea_string)
         if not parsed_sentence:
-            rospy.logdebug("Failed to parse NMEA sentence. Sentece was: %s" % nmea_string)
+            rospy.logdebug(
+                "Failed to parse NMEA sentence. Sentence was: %s" %
+                nmea_string)
             return False
 
         if timestamp:
@@ -130,22 +134,24 @@ class RosNMEADriver(object):
             self.fix_pub.publish(current_fix)
 
             if not math.isnan(data['utc_time']):
-                current_time_ref.time_ref = rospy.Time.from_sec(data['utc_time'])
+                current_time_ref.time_ref = rospy.Time.from_sec(
+                    data['utc_time'])
                 self.last_valid_fix_time = current_time_ref
                 self.time_ref_pub.publish(current_time_ref)
 
         elif not self.use_RMC and 'VTG' in parsed_sentence:
             data = parsed_sentence['VTG']
 
-            # Only report VTG data when you've received a valid GGA fix as well.
+            # Only report VTG data when you've received a valid GGA fix as
+            # well.
             if self.valid_fix:
                 current_vel = TwistStamped()
                 current_vel.header.stamp = current_time
                 current_vel.header.frame_id = frame_id
                 current_vel.twist.linear.x = data['speed'] * \
-                                             math.sin(data['true_course'])
+                    math.sin(data['true_course'])
                 current_vel.twist.linear.y = data['speed'] * \
-                                             math.cos(data['true_course'])
+                    math.cos(data['true_course'])
                 self.vel_pub.publish(current_vel)
 
         elif 'RMC' in parsed_sentence:
@@ -177,10 +183,12 @@ class RosNMEADriver(object):
                 self.fix_pub.publish(current_fix)
 
                 if not math.isnan(data['utc_time']):
-                    current_time_ref.time_ref = rospy.Time.from_sec(data['utc_time'])
+                    current_time_ref.time_ref = rospy.Time.from_sec(
+                        data['utc_time'])
                     self.time_ref_pub.publish(current_time_ref)
 
-            # Publish velocity from RMC regardless, since GGA doesn't provide it.
+            # Publish velocity from RMC regardless, since GGA doesn't provide
+            # it.
             if data['fix_valid']:
                 current_vel = TwistStamped()
                 current_vel.header.stamp = current_time

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -45,8 +45,10 @@ class RosNMEADriver(object):
     def __init__(self):
         self.fix_pub = rospy.Publisher('fix', NavSatFix, queue_size=1)
         self.vel_pub = rospy.Publisher('vel', TwistStamped, queue_size=1)
-        self.time_ref_pub = rospy.Publisher(
-            'time_reference', TimeReference, queue_size=1)
+        self.use_GNSS_time = rospy.get_param('~use_GNSS_time', False)
+        if not self.use_GNSS_time:
+            self.time_ref_pub = rospy.Publisher(
+                'time_reference', TimeReference, queue_size=1)
 
         self.time_ref_source = rospy.get_param('~time_ref_source', None)
         self.use_RMC = rospy.get_param('~useRMC', False)
@@ -75,16 +77,24 @@ class RosNMEADriver(object):
         current_fix = NavSatFix()
         current_fix.header.stamp = current_time
         current_fix.header.frame_id = frame_id
-        current_time_ref = TimeReference()
-        current_time_ref.header.stamp = current_time
-        current_time_ref.header.frame_id = frame_id
-        if self.time_ref_source:
-            current_time_ref.source = self.time_ref_source
-        else:
-            current_time_ref.source = frame_id
+        if not self.use_GNSS_time:
+            current_time_ref = TimeReference()
+            current_time_ref.header.stamp = current_time
+            current_time_ref.header.frame_id = frame_id
+            if self.time_ref_source:
+                current_time_ref.source = self.time_ref_source
+            else:
+                current_time_ref.source = frame_id
 
         if not self.use_RMC and 'GGA' in parsed_sentence:
             data = parsed_sentence['GGA']
+
+            if self.use_GNSS_time:
+                if math.isnan(data['utc_time'][0]):
+                    rospy.logwarn("Time in the NMEA sentence is NOT valid")
+                    return False
+                current_fix.header.stamp = rospy.Time(data['utc_time'][0], data['utc_time'][1])
+
             gps_qual = data['fix_type']
             if gps_qual == 0:
                 current_fix.status.status = NavSatStatus.STATUS_NO_FIX
@@ -133,9 +143,9 @@ class RosNMEADriver(object):
 
             self.fix_pub.publish(current_fix)
 
-            if not math.isnan(data['utc_time']):
-                current_time_ref.time_ref = rospy.Time.from_sec(
-                    data['utc_time'])
+            if not (math.isnan(data['utc_time'][0]) or self.use_GNSS_time):
+                current_time_ref.time_ref = rospy.Time(
+                    data['utc_time'][0], data['utc_time'][1])
                 self.last_valid_fix_time = current_time_ref
                 self.time_ref_pub.publish(current_time_ref)
 
@@ -156,6 +166,12 @@ class RosNMEADriver(object):
 
         elif 'RMC' in parsed_sentence:
             data = parsed_sentence['RMC']
+
+            if self.use_GNSS_time:
+                if math.isnan(data['utc_time'][0]):
+                    rospy.logwarn("Time in the NMEA sentence is NOT valid")
+                    return False
+                current_fix.header.stamp = rospy.Time(data['utc_time'][0], data['utc_time'][1])
 
             # Only publish a fix from RMC if the use_RMC flag is set.
             if self.use_RMC:
@@ -182,9 +198,9 @@ class RosNMEADriver(object):
 
                 self.fix_pub.publish(current_fix)
 
-                if not math.isnan(data['utc_time']):
-                    current_time_ref.time_ref = rospy.Time.from_sec(
-                        data['utc_time'])
+                if not (math.isnan(data['utc_time'][0]) or self.use_GNSS_time):
+                    current_time_ref.time_ref = rospy.Time(
+                        data['utc_time'][0], data['utc_time'][1])
                     self.time_ref_pub.publish(current_time_ref)
 
             # Publish velocity from RMC regardless, since GGA doesn't provide

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Provides a driver for NMEA GNSS devices."""
+
 import math
 
 import rospy
@@ -42,7 +44,27 @@ import libnmea_navsat_driver.parser
 
 
 class RosNMEADriver(object):
+    """ROS driver for NMEA GNSS devices."""
+
     def __init__(self):
+        """Initialize the ROS NMEA driver.
+
+        Creates the following ROS publishers:
+            NavSatFix publisher on the 'fix' channel.
+            TwistStamped publisher on the 'vel' channel.
+            QuaternionStamped publisher on the 'heading' channel.
+            TimeReference publisher on the 'time_reference' channel.
+
+        Reads the following ROS parameters:
+            ~time_ref_source (str): The name of the source in published TimeReference messages. (default None)
+            ~useRMC (bool): If true, use RMC NMEA messages. If false, use GGA and VTG messages. (default False)
+            ~epe_quality0 (float): Value to use for default EPE quality for fix type 0. (default 1000000)
+            ~epe_quality1 (float): Value to use for default EPE quality for fix type 1. (default 4.0)
+            ~epe_quality2 (float): Value to use for default EPE quality for fix type 2. (default (0.1)
+            ~epe_quality4 (float): Value to use for default EPE quality for fix type 4. (default 0.02)
+            ~epe_quality5 (float): Value to use for default EPE quality for fix type 5. (default 4.0)
+            ~epe_quality9 (float): Value to use for default EPE quality for fix type 9. (default 3.0)
+        """
         self.fix_pub = rospy.Publisher('fix', NavSatFix, queue_size=1)
         self.vel_pub = rospy.Publisher('vel', TwistStamped, queue_size=1)
         self.use_GNSS_time = rospy.get_param('~use_GNSS_time', False)
@@ -54,9 +76,18 @@ class RosNMEADriver(object):
         self.use_RMC = rospy.get_param('~useRMC', False)
         self.valid_fix = False
 
-    # Returns True if we successfully did something with the passed in
-    # nmea_string
     def add_sentence(self, nmea_string, frame_id, timestamp=None):
+        """Public method to provide a new NMEA sentence to the driver.
+
+        Args:
+            nmea_string (str): NMEA sentence in string form.
+            frame_id (str): TF frame ID of the GPS receiver.
+            timestamp(rospy.Time, optional): Time the sentence was received.
+                If timestamp is not specified, the current time is used.
+
+        Returns:
+            bool: True if the NMEA string is successfully processed, False if there is an error.
+        """
         if not check_nmea_checksum(nmea_string):
             rospy.logwarn("Received a sentence with an invalid checksum. " +
                           "Sentence was: %s" % repr(nmea_string))
@@ -158,10 +189,8 @@ class RosNMEADriver(object):
                 current_vel = TwistStamped()
                 current_vel.header.stamp = current_time
                 current_vel.header.frame_id = frame_id
-                current_vel.twist.linear.x = data['speed'] * \
-                    math.sin(data['true_course'])
-                current_vel.twist.linear.y = data['speed'] * \
-                    math.cos(data['true_course'])
+                current_vel.twist.linear.x = data['speed'] * math.sin(data['true_course'])
+                current_vel.twist.linear.y = data['speed'] * math.cos(data['true_course'])
                 self.vel_pub.publish(current_vel)
 
         elif 'RMC' in parsed_sentence:
@@ -217,13 +246,19 @@ class RosNMEADriver(object):
         else:
             return False
 
-    """Helper method for getting the frame_id with the correct TF prefix"""
-
     @staticmethod
     def get_frame_id():
+        """Get the TF frame_id.
+
+        Queries rosparam for the ~frame_id param. If a tf_prefix param is set,
+        the frame_id is prefixed with the prefix.
+
+        Returns:
+            str: The fully-qualified TF frame ID.
+        """
         frame_id = rospy.get_param('~frame_id', 'gps')
         if frame_id[0] != "/":
-            """Add the TF prefix"""
+            # Add the TF prefix
             prefix = ""
             prefix_param = rospy.search_param('tf_prefix')
             if prefix_param:

--- a/src/libnmea_navsat_driver/nodes/__init__.py
+++ b/src/libnmea_navsat_driver/nodes/__init__.py
@@ -1,0 +1,6 @@
+"""Defines ROS node executables.
+
+The python nodes in this package are defined as thin wrapper scripts in the scripts/ directory.
+Each wrapper script has a corresponding module in this directory. Splitting the executable from
+the code makes testing easier and is inline with good practices for developing python executables.
+"""

--- a/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Defines the main method for the nmea_serial_driver executable."""
+
 import serial
 import sys
 
@@ -39,6 +41,14 @@ from libnmea_navsat_driver.driver import RosNMEADriver
 
 
 def main():
+    """Create and run the nmea_serial_driver ROS node.
+
+    Creates a ROS NMEA Driver and feeds it NMEA sentence strings from a serial device.
+
+    ROS parameters:
+        ~port (str): Path of the serial device to open.
+        ~baud (int): Baud rate to configure the serial device.
+    """
     rospy.init_node('nmea_serial_driver')
 
     serial_port = rospy.get_param('~port', '/dev/ttyUSB0')

--- a/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
@@ -1,8 +1,6 @@
-#! /usr/bin/env python
-
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2019, Ed Venator <evenator@gmail.com>
+# Copyright (c) 2013, Eric Perko
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,6 +30,40 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import libnmea_navsat_driver.nodes.nmea_socket_driver
+import serial
+import sys
 
-libnmea_navsat_driver.nodes.nmea_socket_driver.main()
+import rospy
+
+from libnmea_navsat_driver.driver import RosNMEADriver
+
+
+def main():
+    rospy.init_node('nmea_serial_driver')
+
+    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
+    serial_baud = rospy.get_param('~baud', 4800)
+    frame_id = RosNMEADriver.get_frame_id()
+
+    try:
+        GPS = serial.Serial(port=serial_port, baudrate=serial_baud, timeout=2)
+
+        try:
+            driver = RosNMEADriver()
+            while not rospy.is_shutdown():
+                data = GPS.readline().strip()
+                try:
+                    driver.add_sentence(data, frame_id)
+                except ValueError as e:
+                    rospy.logwarn(
+                        "Value error, likely due to missing fields in the NMEA message. "
+                        "Error was: %s. Please report this issue at "
+                        "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
+                        "sentences that caused it." %
+                        e)
+
+        except (rospy.ROSInterruptException, serial.serialutil.SerialException):
+            GPS.close()  # Close GPS serial port
+    except serial.SerialException as ex:
+        rospy.logfatal(
+            "Could not open serial port: I/O error({0}): {1}".format(ex.errno, ex.strerror))

--- a/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
@@ -1,0 +1,104 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Rein Appeldoorn
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the names of the authors nor the names of their
+#    affiliated organizations may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import socket
+import sys
+
+import rospy
+
+from libnmea_navsat_driver.driver import RosNMEADriver
+
+
+def main():
+    rospy.init_node('nmea_socket_driver')
+
+    try:
+        local_ip = rospy.get_param('~ip', '0.0.0.0')
+        local_port = rospy.get_param('~port', 10110)
+        buffer_size = rospy.get_param('~buffer_size', 4096)
+        timeout = rospy.get_param('~timeout_sec', 2)
+    except KeyError as e:
+        rospy.logerr("Parameter %s not found" % e)
+        sys.exit(1)
+
+    frame_id = RosNMEADriver.get_frame_id()
+
+    driver = RosNMEADriver()
+
+    # Connection-loop: connect and keep receiving. If receiving fails,
+    # reconnect
+    while not rospy.is_shutdown():
+        try:
+            # Create a socket
+            socket_ = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+            # Bind the socket to the port
+            socket_.bind((local_ip, local_port))
+
+            # Set timeout
+            socket_.settimeout(timeout)
+        except socket.error as exc:
+            rospy.logerr(
+                "Caught exception socket.error when setting up socket: %s" %
+                exc)
+            sys.exit(1)
+
+        # recv-loop: When we're connected, keep receiving stuff until that
+        # fails
+        while not rospy.is_shutdown():
+            try:
+                data, remote_address = socket_.recvfrom(buffer_size)
+
+                # strip the data
+                data_list = data.strip().split("\n")
+
+                for data in data_list:
+
+                    try:
+                        driver.add_sentence(data, frame_id)
+                    except ValueError as e:
+                        rospy.logwarn(
+                            "Value error, likely due to missing fields in the NMEA message. "
+                            "Error was: %s. Please report this issue at "
+                            "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
+                            "sentences that caused it." %
+                            e)
+
+            except socket.error as exc:
+                rospy.logerr(
+                    "Caught exception socket.error during recvfrom: %s" % exc)
+                socket_.close()
+                # This will break out of the recv-loop so we start another
+                # iteration of the connection-loop
+                break
+
+        socket_.close()  # Close socket

--- a/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
@@ -33,12 +33,39 @@
 """Defines the main method for the nmea_socket_driver executable."""
 
 
-import socket
+import select
 import sys
+import traceback
+
+try:
+    import socketserver
+except ImportError:
+    import SocketServer as socketserver  # Python 2.7
 
 import rospy
 
 from libnmea_navsat_driver.driver import RosNMEADriver
+
+
+class NMEAMessageHandler(socketserver.DatagramRequestHandler):
+    def handle(self):
+        for line in self.rfile:
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                self.server.driver.add_sentence(line, self.server.frame_id)
+            except ValueError:
+                rospy.logwarn(
+                    "ValueError, likely due to missing fields in the NMEA "
+                    "message. Please report this issue at "
+                    "https://github.com/ros-drivers/nmea_navsat_driver"
+                    ", including the following:\n\n"
+                    "```\n" +
+                    repr(line) + "\n\n" +
+                    traceback.format_exc() +
+                    "```")
 
 
 def main():
@@ -49,7 +76,6 @@ def main():
     ROS parameters:
         ~ip (str): IPV4 address of the socket to open.
         ~port (int): Local port of the socket to open.
-        ~buffer_size (int): The size of the buffer for the socket, in bytes.
         ~timeout (float): The time out period for the socket, in seconds.
     """
     rospy.init_node('nmea_socket_driver')
@@ -57,61 +83,28 @@ def main():
     try:
         local_ip = rospy.get_param('~ip', '0.0.0.0')
         local_port = rospy.get_param('~port', 10110)
-        buffer_size = rospy.get_param('~buffer_size', 4096)
         timeout = rospy.get_param('~timeout_sec', 2)
     except KeyError as e:
         rospy.logerr("Parameter %s not found" % e)
         sys.exit(1)
 
-    frame_id = RosNMEADriver.get_frame_id()
+    # Create a socket
+    server = socketserver.UDPServer((local_ip, local_port), NMEAMessageHandler,
+                                    bind_and_activate=False)
+    server.frame_id = RosNMEADriver.get_frame_id()
+    server.driver = RosNMEADriver()
 
-    driver = RosNMEADriver()
+    # Start listening for connections
+    server.server_bind()
+    server.server_activate()
 
-    # Connection-loop: connect and keep receiving. If receiving fails,
-    # reconnect
-    while not rospy.is_shutdown():
-        try:
-            # Create a socket
-            socket_ = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-
-            # Bind the socket to the port
-            socket_.bind((local_ip, local_port))
-
-            # Set timeout
-            socket_.settimeout(timeout)
-        except socket.error as exc:
-            rospy.logerr(
-                "Caught exception socket.error when setting up socket: %s" %
-                exc)
-            sys.exit(1)
-
-        # recv-loop: When we're connected, keep receiving stuff until that
-        # fails
+    # Handle incoming connections until ROS shuts down
+    try:
         while not rospy.is_shutdown():
-            try:
-                data, remote_address = socket_.recvfrom(buffer_size)
-
-                # strip the data
-                data_list = data.strip().split("\n")
-
-                for data in data_list:
-
-                    try:
-                        driver.add_sentence(data, frame_id)
-                    except ValueError as e:
-                        rospy.logwarn(
-                            "Value error, likely due to missing fields in the NMEA message. "
-                            "Error was: %s. Please report this issue at "
-                            "github.com/ros-drivers/nmea_navsat_driver, including a bag file with the NMEA "
-                            "sentences that caused it." %
-                            e)
-
-            except socket.error as exc:
-                rospy.logerr(
-                    "Caught exception socket.error during recvfrom: %s" % exc)
-                socket_.close()
-                # This will break out of the recv-loop so we start another
-                # iteration of the connection-loop
-                break
-
-        socket_.close()  # Close socket
+            rlist, _, _ = select.select([server], [], [], timeout)
+            if server in rlist:
+                server.handle_request()
+    except Exception:
+        rospy.logerr(traceback.format_exc())
+    finally:
+        server.server_close()

--- a/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
@@ -30,6 +30,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Defines the main method for the nmea_socket_driver executable."""
+
+
 import socket
 import sys
 
@@ -39,6 +42,16 @@ from libnmea_navsat_driver.driver import RosNMEADriver
 
 
 def main():
+    """Create and run the nmea_socket_driver ROS node.
+
+    Creates a ROS NMEA Driver and feeds it NMEA sentence strings from a UDP socket.
+
+    ROS parameters:
+        ~ip (str): IPV4 address of the socket to open.
+        ~port (int): Local port of the socket to open.
+        ~buffer_size (int): The size of the buffer for the socket, in bytes.
+        ~timeout (float): The time out period for the socket, in seconds.
+    """
     rospy.init_node('nmea_socket_driver')
 
     try:

--- a/src/libnmea_navsat_driver/nodes/nmea_topic_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_driver.py
@@ -1,8 +1,6 @@
-#! /usr/bin/env python
-
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2019, Ed Venator <evenator@gmail.com>
+# Copyright (c) 2013, Eric Perko
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,6 +30,32 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import libnmea_navsat_driver.nodes.nmea_socket_driver
+from nmea_msgs.msg import Sentence
+import rospy
 
-libnmea_navsat_driver.nodes.nmea_socket_driver.main()
+from libnmea_navsat_driver.driver import RosNMEADriver
+
+
+def nmea_sentence_callback(nmea_sentence, driver):
+    try:
+        driver.add_sentence(
+            nmea_sentence.sentence,
+            frame_id=nmea_sentence.header.frame_id,
+            timestamp=nmea_sentence.header.stamp)
+    except ValueError as e:
+        rospy.logwarn(
+            "Value error, likely due to missing fields in the NMEA message. "
+            "Error was: %s. Please report this issue at github.com/ros-drivers/nmea_navsat_driver, "
+            "including a bag file with the NMEA sentences that caused it." %
+            e)
+
+
+def main():
+    rospy.init_node('nmea_topic_driver')
+
+    driver = RosNMEADriver()
+
+    rospy.Subscriber("nmea_sentence", Sentence, nmea_sentence_callback,
+                     driver)
+
+    rospy.spin()

--- a/src/libnmea_navsat_driver/nodes/nmea_topic_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_driver.py
@@ -30,6 +30,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Defines the main method for the nmea_topic_driver executable."""
+
+
 from nmea_msgs.msg import Sentence
 import rospy
 
@@ -37,6 +40,12 @@ from libnmea_navsat_driver.driver import RosNMEADriver
 
 
 def nmea_sentence_callback(nmea_sentence, driver):
+    """Process a NMEA sentence message with a RosNMEADriver.
+
+    Args:
+        nmea_sentence (nmea_msgs.msg.Sentence): NMEA sentence message to feed to the driver.
+        driver (RosNMEADriver): Driver to feed the sentence.
+    """
     try:
         driver.add_sentence(
             nmea_sentence.sentence,
@@ -51,6 +60,13 @@ def nmea_sentence_callback(nmea_sentence, driver):
 
 
 def main():
+    """Create and run the nmea_topic_driver ROS node.
+
+    Creates a NMEA Driver and feeds it NMEA sentence strings from a ROS subscriber.
+
+    ROS subscribers:
+        mea_sentence (nmea_msgs.msg.Sentence): NMEA sentence messages to feed to the driver.
+    """
     rospy.init_node('nmea_topic_driver')
 
     driver = RosNMEADriver()

--- a/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
@@ -1,8 +1,6 @@
-#! /usr/bin/env python
-
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2019, Ed Venator <evenator@gmail.com>
+# Copyright (c) 2013, Eric Perko
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,6 +30,36 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import libnmea_navsat_driver.nodes.nmea_socket_driver
+import serial
 
-libnmea_navsat_driver.nodes.nmea_socket_driver.main()
+from nmea_msgs.msg import Sentence
+import rospy
+
+from libnmea_navsat_driver.driver import RosNMEADriver
+
+
+def main():
+    rospy.init_node('nmea_topic_serial_reader')
+
+    nmea_pub = rospy.Publisher("nmea_sentence", Sentence)
+
+    serial_port = rospy.get_param('~port', '/dev/ttyUSB0')
+    serial_baud = rospy.get_param('~baud', 4800)
+
+    # Get the frame_id
+    frame_id = RosNMEADriver.get_frame_id()
+
+    try:
+        GPS = serial.Serial(port=serial_port, baudrate=serial_baud, timeout=2)
+        while not rospy.is_shutdown():
+            data = GPS.readline().strip()
+
+            sentence = Sentence()
+            sentence.header.stamp = rospy.get_rostime()
+            sentence.header.frame_id = frame_id
+            sentence.sentence = data
+
+            nmea_pub.publish(sentence)
+
+    except rospy.ROSInterruptException:
+        GPS.close()  # Close GPS serial port

--- a/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
@@ -30,6 +30,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Defines the main method for the nmea_topic_serial_reader executable."""
+
 import serial
 
 from nmea_msgs.msg import Sentence
@@ -39,6 +41,18 @@ from libnmea_navsat_driver.driver import RosNMEADriver
 
 
 def main():
+    """Create and run the nmea_topic_serial_reader ROS node.
+
+    Opens a serial device and publishes data from the device as nmea_msgs.msg.Sentence messages.
+
+    ROS parameters:
+        ~port (str): Path of the serial device to open.
+        ~baud (int): Baud rate to configure the serial device.
+
+    ROS publishers:
+        nmea_sentence (nmea_msgs.msg.Sentence): Publishes each line from the open serial device as a new
+            message. The header's stamp is set to the rostime when the data is read from the serial device.
+    """
     rospy.init_node('nmea_topic_serial_reader')
 
     nmea_pub = rospy.Publisher("nmea_sentence", Sentence)

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import re
-import time
+import datetime
 import calendar
 import math
 import logging
@@ -61,22 +61,68 @@ def convert_longitude(field):
 
 
 def convert_time(nmea_utc):
-    # Get current time in UTC for date information
-    utc_struct = time.gmtime()  # immutable, so cannot modify this one
-    utc_list = list(utc_struct)
+    """
+    Parameters:
+        nmea_utc - nmea sentence
+
+    Returns:
+        2-tuple of (unix seconds, nanoseconds),
+        or (NaN, NaN) if sentence does not contain valid time
+    """
     # If one of the time fields is empty, return NaN seconds
     if not nmea_utc[0:2] or not nmea_utc[2:4] or not nmea_utc[4:6]:
-        return float('NaN')
-    else:
-        hours = int(nmea_utc[0:2])
-        minutes = int(nmea_utc[2:4])
-        seconds = int(nmea_utc[4:6])
-        utc_list[3] = hours
-        utc_list[4] = minutes
-        utc_list[5] = seconds
-        unix_time = calendar.timegm(tuple(utc_list))
-        return unix_time
+        return (float('NaN'), float('NaN'))
 
+    # Get current time in UTC for date information
+    utc_time = datetime.datetime.utcnow()
+    hours = int(nmea_utc[0:2])
+    minutes = int(nmea_utc[2:4])
+    seconds = int(nmea_utc[4:6])
+    nanosecs = int(nmea_utc[7:]) * pow(10, 9 - len(nmea_utc[7:]))
+
+    ## resolve the ambiguity of day
+    day_offset = int((utc_time.hour - hours)/12.0)
+    utc_time += datetime.timedelta(day_offset)
+    utc_time.replace(hour=hours, minute=minutes, second=seconds)
+
+    unix_secs = calendar.timegm(utc_time.timetuple())
+    return (unix_secs, nanosecs)
+
+def convert_time_rmc(date_str, time_str):
+    """
+    Parameters:
+        nmea_utc - nmea sentence
+
+    Returns:
+        2-tuple of (unix seconds, nanoseconds),
+        or (NaN, NaN) if sentence does not contain valid time
+    """
+    # If one of the time fields is empty, return NaN seconds
+    if not time_str[0:2] or not time_str[2:4] or not time_str[4:6]:
+        return (float('NaN'), float('NaN'))
+
+    pc_year = datetime.date.today().year
+
+    ## resolve the ambiguity of century
+    """
+    example 1: utc_year = 99, pc_year = 2100
+    years = 2100 + int((2100 % 100 - 99) / 50.0) = 2099
+    example 2: utc_year = 00, pc_year = 2099
+    years = 2099 + int((2099 % 100 - 00) / 50.0) = 2100
+    """
+    utc_year = int(date_str[4:6])
+    years = pc_year + int((pc_year % 100 - utc_year) / 50.0)
+
+    months = int(date_str[2:4])
+    days = int(date_str[0:2])
+
+    hours = int(time_str[0:2])
+    minutes = int(time_str[2:4])
+    seconds = int(time_str[4:6])
+    nanosecs = int(time_str[7:]) * pow(10, 9 - len(time_str[7:]))
+
+    unix_secs = calendar.timegm((years, months, days, hours, minutes, seconds))
+    return (unix_secs, nanosecs)
 
 def convert_status_flag(status_flag):
     if status_flag == "A":
@@ -113,7 +159,6 @@ parse_maps = {
         ("utc_time", convert_time, 1),
     ],
     "RMC": [
-        ("utc_time", convert_time, 1),
         ("fix_valid", convert_status_flag, 2),
         ("latitude", convert_latitude, 3),
         ("latitude_direction", str, 4),
@@ -166,5 +211,8 @@ def parse_nmea_sentence(nmea_sentence):
     parsed_sentence = {}
     for entry in parse_map:
         parsed_sentence[entry[0]] = entry[1](fields[entry[2]])
+
+    if sentence_type == "RMC":
+        parsed_sentence["utc_time"] = convert_time_rmc(fields[9], fields[1])
 
     return {sentence_type: parsed_sentence}

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -30,15 +30,27 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+"""Parsing functions for NMEA sentence strings."""
+
 import re
 import datetime
 import calendar
 import math
 import logging
+
+
 logger = logging.getLogger('rosout')
 
 
 def safe_float(field):
+    """Convert  field to a float.
+
+    Args:
+        field: The field (usually a str) to convert to float.
+
+    Returns:
+        The float value represented by field or NaN if float conversion throws a ValueError.
+    """
     try:
         return float(field)
     except ValueError:
@@ -46,6 +58,14 @@ def safe_float(field):
 
 
 def safe_int(field):
+    """Convert  field to an int.
+
+    Args:
+        field: The field (usually a str) to convert to int.
+
+    Returns:
+        The int value represented by field or 0 if int conversion throws a ValueError.
+    """
     try:
         return int(field)
     except ValueError:
@@ -53,21 +73,48 @@ def safe_int(field):
 
 
 def convert_latitude(field):
+    """Convert a latitude string to floating point decimal degrees.
+
+    Args:
+        field (str): Latitude string, expected to be formatted as DDMM.MMM, where
+            DD is the latitude degrees, and MM.MMM are the minutes latitude.
+
+    Returns:
+        Floating point latitude in decimal degrees.
+    """
     return safe_float(field[0:2]) + safe_float(field[2:]) / 60.0
 
 
 def convert_longitude(field):
+    """Convert a longitude string to floating point decimal degrees.
+
+    Args:
+        field (str): Longitude string, expected to be formatted as DDDMM.MMM, where
+            DDD is the longitude degrees, and MM.MMM are the minutes longitude.
+
+    Returns:
+        Floating point latitude in decimal degrees.
+    """
     return safe_float(field[0:3]) + safe_float(field[3:]) / 60.0
 
 
 def convert_time(nmea_utc):
-    """
-    Parameters:
-        nmea_utc - nmea sentence
+    """Extract time info from a NMEA UTC time string and use it to generate a UNIX epoch time.
+
+    Time information (hours, minutes, seconds) is extracted from the given string and augmented
+    with the date, which is taken from the current system time on the host computer (i.e. UTC now).
+    The date ambiguity is resolved by adding a day to the current date if the host time is more than
+    12 hours behind the NMEA time and subtracting a day from the current date if the host time is
+    more than 12 hours ahead of the NMEA time.
+
+    Args:
+        nmea_utc (str): NMEA UTC time string to convert. The expected format is HHMMSS.SS where
+            HH is the number of hours [0,24), MM is the number of minutes [0,60),
+            and SS.SS is the number of seconds [0,60) of the time in UTC.
 
     Returns:
-        2-tuple of (unix seconds, nanoseconds),
-        or (NaN, NaN) if sentence does not contain valid time
+        tuple(int, int): 2-tuple of (unix seconds, nanoseconds) if the sentence contains valid time.
+        tuple(float, float): 2-tuple of (NaN, NaN) if the sentence does not contain valid time.
     """
     # If one of the time fields is empty, return NaN seconds
     if not nmea_utc[0:2] or not nmea_utc[2:4] or not nmea_utc[4:6]:
@@ -80,7 +127,7 @@ def convert_time(nmea_utc):
     seconds = int(nmea_utc[4:6])
     nanosecs = int(nmea_utc[7:]) * pow(10, 9 - len(nmea_utc[7:]))
 
-    ## resolve the ambiguity of day
+    # Resolve the ambiguity of day
     day_offset = int((utc_time.hour - hours)/12.0)
     utc_time += datetime.timedelta(day_offset)
     utc_time.replace(hour=hours, minute=minutes, second=seconds)
@@ -88,14 +135,19 @@ def convert_time(nmea_utc):
     unix_secs = calendar.timegm(utc_time.timetuple())
     return (unix_secs, nanosecs)
 
+
 def convert_time_rmc(date_str, time_str):
-    """
-    Parameters:
-        nmea_utc - nmea sentence
+    """Convert a NMEA RMC date string and time string to UNIX epoch time.
+
+    Args:
+        date_str (str): NMEA UTC date string to convert, formatted as DDMMYY.
+        nmea_utc (str): NMEA UTC time string to convert. The expected format is HHMMSS.SS where
+            HH is the number of hours [0,24), MM is the number of minutes [0,60),
+            and SS.SS is the number of seconds [0,60) of the time in UTC.
 
     Returns:
-        2-tuple of (unix seconds, nanoseconds),
-        or (NaN, NaN) if sentence does not contain valid time
+        tuple(int, int): 2-tuple of (unix seconds, nanoseconds) if the sentence contains valid time.
+        tuple(float, float): 2-tuple of (NaN, NaN) if the sentence does not contain valid time.
     """
     # If one of the time fields is empty, return NaN seconds
     if not time_str[0:2] or not time_str[2:4] or not time_str[4:6]:
@@ -103,7 +155,7 @@ def convert_time_rmc(date_str, time_str):
 
     pc_year = datetime.date.today().year
 
-    ## resolve the ambiguity of century
+    # Resolve the ambiguity of century
     """
     example 1: utc_year = 99, pc_year = 2100
     years = 2100 + int((2100 % 100 - 99) / 50.0) = 2099
@@ -124,7 +176,16 @@ def convert_time_rmc(date_str, time_str):
     unix_secs = calendar.timegm((years, months, days, hours, minutes, seconds))
     return (unix_secs, nanosecs)
 
+
 def convert_status_flag(status_flag):
+    """Convert a NMEA RMB/RMC status flag to bool.
+
+    Args:
+        status_flag (str): NMEA status flag, which should be "A" or "V"
+
+    Returns:
+        True if the status_flag is "A" for Active.
+    """
     if status_flag == "A":
         return True
     elif status_flag == "V":
@@ -134,17 +195,31 @@ def convert_status_flag(status_flag):
 
 
 def convert_knots_to_mps(knots):
+    """Convert a speed in knots to meters per second.
+
+    Args:
+        knots (float, int, or str): Speed in knots.
+
+    Returns:
+        The value of safe_float(knots) converted from knots to meters/second.
+    """
     return safe_float(knots) * 0.514444444444
 
 
-# Need this wrapper because math.radians doesn't auto convert inputs
 def convert_deg_to_rads(degs):
+    """Convert an angle in degrees to radians.
+
+    This wrapper is needed because math.radians doesn't accept non-numeric inputs.
+
+    Args:
+        degs (float, int, or str): Angle in degrees
+
+    Returns:
+        The value of safe_float(degs) converted from degrees to radians.
+    """
     return math.radians(safe_float(degs))
 
 
-"""Format for this is a sentence identifier (e.g. "GGA") as the key, with a
-tuple of tuples where each tuple is a field name, conversion function and index
-into the split sentence"""
 parse_maps = {
     "GGA": [
         ("fix_type", int, 6),
@@ -185,9 +260,22 @@ parse_maps = {
         ("speed", convert_knots_to_mps, 5)
     ]
 }
+"""A dictionary that maps from sentence identifier string (e.g. "GGA") to a list of tuples.
+Each tuple is a three-tuple of (str: field name, callable: conversion function, int: field index).
+The parser splits the sentence into comma-delimited fields. The string value of each field is passed
+to the appropriate conversion function based on the field index."""
 
 
 def parse_nmea_sentence(nmea_sentence):
+    """Parse a NMEA sentence string into a dictionary.
+
+    Args:
+        nmea_sentence (str): A single NMEA sentence of one of the types in parse_maps.
+
+    Returns:
+        A dict mapping string field names to values for each field in the NMEA sentence or
+        False if the sentence could not be parsed.
+    """
     # Check for a valid nmea sentence
 
     if not re.match(

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -95,6 +95,7 @@ def convert_knots_to_mps(knots):
 def convert_deg_to_rads(degs):
     return math.radians(safe_float(degs))
 
+
 """Format for this is a sentence identifier (e.g. "GGA") as the key, with a
 tuple of tuples where each tuple is a field name, conversion function and index
 into the split sentence"""
@@ -110,7 +111,7 @@ parse_maps = {
         ("hdop", safe_float, 8),
         ("num_satellites", safe_int, 7),
         ("utc_time", convert_time, 1),
-        ],
+    ],
     "RMC": [
         ("utc_time", convert_time, 1),
         ("fix_valid", convert_status_flag, 2),
@@ -120,7 +121,7 @@ parse_maps = {
         ("longitude_direction", str, 6),
         ("speed", convert_knots_to_mps, 7),
         ("true_course", convert_deg_to_rads, 8),
-        ],
+    ],
     "GST": [
         ("utc_time", convert_time, 1),
         ("ranges_std_dev", safe_float, 2),
@@ -130,30 +131,32 @@ parse_maps = {
         ("lat_std_dev", safe_float, 6),
         ("lon_std_dev", safe_float, 7),
         ("alt_std_dev", safe_float, 8),
-        ],
+    ],
     "HDT": [
         ("heading", safe_float, 1),
-        ],
-    "VTG":[
-        ("true_course", safe_float,1),
-        ("speed", convert_knots_to_mps,5)
-        ]
-    }
+    ],
+    "VTG": [
+        ("true_course", safe_float, 1),
+        ("speed", convert_knots_to_mps, 5)
+    ]
+}
 
 
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
 
-    if not re.match('(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
-        logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
-                     % repr(nmea_sentence))
+    if not re.match(
+            r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+        logger.debug(
+            "Regex didn't match, sentence not valid NMEA? Sentence was: %s" %
+            repr(nmea_sentence))
         return False
     fields = [field.strip(',') for field in nmea_sentence.split(',')]
 
     # Ignore the $ and talker ID portions (e.g. GP)
     sentence_type = fields[0][3:]
 
-    if not sentence_type in parse_maps:
+    if sentence_type not in parse_maps:
         logger.debug("Sentence type %s not in parse map, ignoring."
                      % repr(sentence_type))
         return False


### PR DESCRIPTION
This PR backports the following PRs from `master` to `melodic-devel`:

- #59 Remove `roslint` as a build dependency
- #60 Add `nmea_serial_driver` launch file
- #68 Fix PEP8 violations
- #76 Refactor nodes into entrypoint scripts
- #79 Add an option to use GNSS time and improve time parsing
- #88 Add documentation and clean up
- #92 rewrite `nmea_socket_driver` to user `serversocket`

These changes do not break the existing API, so they can be backported to the already-released Melodic branch.