### PR TITLE
nmea_topic_driver Ignore carriage returns and new lines.

### DIFF
--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -277,7 +277,7 @@ def parse_nmea_sentence(nmea_sentence):
         False if the sentence could not be parsed.
     """
     # Check for a valid nmea sentence
-
+    nmea_sentence = nmea_sentence.strip("\r\n") # Cut possible carriage return or new line of NMEA Sentence
     if not re.match(
             r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug(

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -277,7 +277,7 @@ def parse_nmea_sentence(nmea_sentence):
         False if the sentence could not be parsed.
     """
     # Check for a valid nmea sentence
-    nmea_sentence = nmea_sentence.strip("\r\n") # Cut possible carriage return or new line of NMEA Sentence
+    nmea_sentence = nmea_sentence.strip("\r\n")  # Cut possible carriage return or new line of NMEA Sentence
     if not re.match(
             r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug(

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -277,7 +277,7 @@ def parse_nmea_sentence(nmea_sentence):
         False if the sentence could not be parsed.
     """
     # Check for a valid nmea sentence
-    nmea_sentence = nmea_sentence.strip("\r\n")  # Cut possible carriage return or new line of NMEA Sentence
+    nmea_sentence = nmea_sentence.strip()  # Cut possible carriage return or new line of NMEA Sentence
     if not re.match(
             r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug(


### PR DESCRIPTION
nmea_topic_driver gets raw NMEA sentences. Those can contain carriage returns and new line. nmea_topic_driver won't parse messages with this characters. They will be removed before parsing now.