### PR TITLE
ROS2: Eloquent changes for python packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     version='0.5.1',
     packages=["libnmea_navsat_driver", "libnmea_navsat_driver.nodes"],
     data_files=[
+        ('share/' + PACKAGE_NAME, ['package.xml']),
         (os.path.join(SHARE_DIR, "launch"), glob(os.path.join("launch", "*.launch.py"))),
         (os.path.join(SHARE_DIR, "config"), glob(os.path.join("config", "*.yaml")))],
     package_dir={'': 'src',},

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,12 @@ setup(
     version='0.5.1',
     packages=["libnmea_navsat_driver", "libnmea_navsat_driver.nodes"],
     data_files=[
+        ('share/ament_index/resource_index/packages',
+         ['resource/' + PACKAGE_NAME]),
         ('share/' + PACKAGE_NAME, ['package.xml']),
         (os.path.join(SHARE_DIR, "launch"), glob(os.path.join("launch", "*.launch.py"))),
         (os.path.join(SHARE_DIR, "config"), glob(os.path.join("config", "*.yaml")))],
-    package_dir={'': 'src',},
+    package_dir={'': 'src', },
     py_modules=[],
     zip_safe=True,
     install_requires=['setuptools',


### PR DESCRIPTION
Some warnings are now showing when installing packages that are missing the `resource` folder and those that does not explicitly install `package.xml` in the share folder.

This PR fixes those issues to remove warnings and future-proof the package.