### PR TITLE
Add missing dependency on tf

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nmea_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
 
   <test_depend>roslint</test_depend>
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
When building the package and running the driver with minimal dependencies installed, a Python error appears because the dependency on tf is not declared in package.xml. Declare that dependency.

Fixes #62.