### PR TITLE
Update pyserial dependency to install it with rosdep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,7 @@
     <exec_depend>rclpy</exec_depend>
     <exec_depend>sensor_msgs</exec_depend>
     <exec_depend>python3-numpy</exec_depend>
-    <exec_depend>python-serial</exec_depend>
+    <exec_depend>python3-serial</exec_depend>
     <exec_depend>python-transforms3d-pip</exec_depend>
 
     <test_depend>python3-pytest</test_depend>


### PR DESCRIPTION
This allows rosdep to find the correct serial package and install it.