### PR TITLE
Make launch file foxy compatible.

### DIFF
--- a/launch/nmea_serial_driver.launch.py
+++ b/launch/nmea_serial_driver.launch.py
@@ -19,14 +19,16 @@ import sys
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription, LaunchIntrospector, LaunchService
-from launch_ros import actions, get_default_launch_description
+from launch_ros import actions
 
 
 def generate_launch_description():
     """Generate a launch description for a single serial driver."""
     config_file = os.path.join(get_package_share_directory("nmea_navsat_driver"), "config", "nmea_serial_driver.yaml")
     driver_node = actions.Node(
-        package='nmea_navsat_driver', node_executable='nmea_serial_driver', output='screen',
+        package='nmea_navsat_driver',
+        executable='nmea_serial_driver',
+        output='screen',
         parameters=[config_file])
 
     return LaunchDescription([driver_node])
@@ -45,7 +47,6 @@ def main(argv):
     print('')
 
     ls = LaunchService()
-    ls.include_launch_description(get_default_launch_description(prefix_output_with_name=False))
     ls.include_launch_description(ld)
     return ls.run()
 


### PR DESCRIPTION
`get_default_launch_description` is non existing anymore in foxy as discussed in https://github.com/ros2/launch_ros/pull/128 so I removed it.

I also changed `node_executable` to `executable` to adhere to the latest foxy API.