### PR TITLE
Fix valid_fix check (#111)

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -209,11 +209,8 @@ class RosNMEADriver(object):
             current_fix.status.status = gps_qual[1]
             current_fix.position_covariance_type = gps_qual[2]
 
-            if gps_qual > 0:
-                self.valid_fix = True
-            else:
-                self.valid_fix = False
-
+            self.valid_fix = (fix_type > 0)
+            
             current_fix.status.service = NavSatStatus.SERVICE_GPS
 
             latitude = data['latitude']


### PR DESCRIPTION
valid_fix should be determined by checking if the fix_type is greater than 0, not the gps_qual. This was never correct, but it at least ran in Python 2. In Python 3, it causes a TypeError.