### PR TITLE
Update to Python3 for ROS Noetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(nmea_navsat_driver)
 
 find_package(catkin REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>nmea_navsat_driver</name>
   <version>0.5.0</version>
   <description>
@@ -17,9 +17,11 @@
   <author>Steven Martin</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>python-catkin-pkg</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</build_depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>python-serial</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-serial</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-serial</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nmea_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>

--- a/scripts/nmea_serial_driver
+++ b/scripts/nmea_serial_driver
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/nmea_socket_driver
+++ b/scripts/nmea_socket_driver
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/nmea_topic_driver
+++ b/scripts/nmea_topic_driver
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/nmea_topic_serial_reader
+++ b/scripts/nmea_topic_serial_reader
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Software License Agreement (BSD License)
 #

--- a/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
@@ -64,8 +64,9 @@ def main():
             driver = RosNMEADriver()
             while not rospy.is_shutdown():
                 data = GPS.readline().strip()
+                nmea_str = data.decode('utf-8')
                 try:
-                    driver.add_sentence(data, frame_id)
+                    driver.add_sentence(nmea_str, frame_id)
                 except ValueError as e:
                     rospy.logwarn(
                         "Value error, likely due to missing fields in the NMEA message. "

--- a/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
@@ -74,7 +74,7 @@ def main():
             sentence = Sentence()
             sentence.header.stamp = rospy.get_rostime()
             sentence.header.frame_id = frame_id
-            sentence.sentence = data
+            sentence.sentence = data.decode('utf-8')
 
             nmea_pub.publish(sentence)
 


### PR DESCRIPTION
Updates for ROS Noetic:

- CMake minimum version is now 3.0.2
- Python version is now 3
- Package.xml version is now 3

Tested on ROS Noetic in Ubuntu 20.04 (Focal) under Windows Subsystem for Linux. Serial drivers working as expected.