### PR TITLE
Fix #115: Decoding errors

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -210,7 +210,7 @@ class RosNMEADriver(object):
             current_fix.position_covariance_type = gps_qual[2]
 
             self.valid_fix = (fix_type > 0)
-            
+
             current_fix.status.service = NavSatStatus.SERVICE_GPS
 
             latitude = data['latitude']

--- a/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
@@ -64,9 +64,12 @@ def main():
             driver = RosNMEADriver()
             while not rospy.is_shutdown():
                 data = GPS.readline().strip()
-                nmea_str = data.decode('utf-8')
                 try:
+                    nmea_str = data.decode('ascii')
                     driver.add_sentence(nmea_str, frame_id)
+                except UnicodeError as e:
+                    rospy.logwarn("Skipped reading a line from the serial device because it could not be "
+                                  "decoded as an ASCII string. The bytes were {0}".format(data))
                 except ValueError as e:
                     rospy.logwarn(
                         "Value error, likely due to missing fields in the NMEA message. "

--- a/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
@@ -74,9 +74,14 @@ def main():
             sentence = Sentence()
             sentence.header.stamp = rospy.get_rostime()
             sentence.header.frame_id = frame_id
-            sentence.sentence = data.decode('utf-8')
 
-            nmea_pub.publish(sentence)
+            try:
+                sentence.sentence = data.decode('ascii')
+            except UnicodeError as e:
+                rospy.logwarn("Skipped reading a line from the serial device because it could not be "
+                              "decoded as an ASCII string. The bytes were {0}".format(data))
+            else:
+                nmea_pub.publish(sentence)
 
     except rospy.ROSInterruptException:
         GPS.close()  # Close GPS serial port


### PR DESCRIPTION
Handle decoding errors when reading from a serial port. NMEA sentences should be ASCII-encoded, but if malformed data comes in from the serial port, it won't decode properly.

If the exception isn't handled, the node will crash. This commonly happens on startup.

When tested with a BU-353S4 receiver, I reproduced the error reported in #115 and now it prints the following warning and does not crash:

```
[WARN] [1602352879.808924]: Skipped reading a line from the serial device because it could not be decoded as an ASCII string. The bytes were b'f\x06\x16&\x06\xe6\x06\x06\x06\xc6F\x06&v\xe6&\x86Fv\xc6\xe6c\x06v\x96V\x86\xe6\x96\x06f\x16\xc6v\x8dY\xc6\x06v\xc6\x16\xe6\x16\xc6&Vv\xe6v\xc6\xd6c\xd666\xe6\x06\xc6\xd6c\xc6\x06\x06\x06\x06\xa6f6k'
```

Also a couple of codestyle fixes.