### PR TITLE
Revert back to python. Let the system decide which python version it is

### DIFF
--- a/scripts/nmea_serial_driver
+++ b/scripts/nmea_serial_driver
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/nmea_socket_driver
+++ b/scripts/nmea_socket_driver
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/nmea_topic_driver
+++ b/scripts/nmea_topic_driver
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # Software License Agreement (BSD License)
 #

--- a/scripts/nmea_topic_serial_reader
+++ b/scripts/nmea_topic_serial_reader
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # Software License Agreement (BSD License)
 #


### PR DESCRIPTION
Revert back to `python` instead of `pyton.X`

In case you are struggling in Ubuntu 20,04 then you probably should:
```sh
sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 20
```

This might fix other issues that you are also probably encountering....

Forcing this to run on python3, breaks the backward compatibility. Better to let the environment to pick which python version it is. 

This PR partially reverts #113 
