### PR TITLE
If heading available, publish IMU msg as well

### DIFF
--- a/config/nmea_serial_driver.yaml
+++ b/config/nmea_serial_driver.yaml
@@ -1,7 +1,7 @@
 nmea_navsat_driver:
   ros__parameters:
-    port: "/dev/tty.usbserial"
+    port: "/dev/ttyACM0"
     baud: 4800
-    frame_id: "gps"
+    frame_id: "gps_link"
     time_ref_source: "gps"
     useRMC: False

--- a/src/libnmea_navsat_driver/checksum_utils.py
+++ b/src/libnmea_navsat_driver/checksum_utils.py
@@ -33,7 +33,7 @@
 
 # Check the NMEA sentence checksum. Return True if passes and False if failed
 def check_nmea_checksum(nmea_sentence):
-    print(nmea_sentence)
+    #print(nmea_sentence)
 
     split_sentence = nmea_sentence.split('*')
     if len(split_sentence) != 2:

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -264,7 +264,7 @@ class Ros2NMEADriver(Node):
                 current_heading = QuaternionStamped()
                 current_heading.header.stamp = current_time
                 current_heading.header.frame_id = frame_id
-                q = quaternion_from_euler(0, 0, -math.radians(data['heading']) - 1.57)
+                q = quaternion_from_euler(0, 0, -math.radians(data['heading']) + 1.57)
                 current_heading.quaternion.w = q[0]
                 current_heading.quaternion.x = q[1]
                 current_heading.quaternion.y = q[2]

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -264,16 +264,16 @@ class Ros2NMEADriver(Node):
                 current_heading = QuaternionStamped()
                 current_heading.header.stamp = current_time
                 current_heading.header.frame_id = frame_id
-                q = quaternion_from_euler(0, 0, math.radians(data['heading']))
-                current_heading.quaternion.x = q[0]
-                current_heading.quaternion.y = q[1]
-                current_heading.quaternion.z = q[2]
-                current_heading.quaternion.w = q[3]
+                q = quaternion_from_euler(0, 0, -math.radians(data['heading']) - 1.57)
+                current_heading.quaternion.w = q[0]
+                current_heading.quaternion.x = q[1]
+                current_heading.quaternion.y = q[2]
+                current_heading.quaternion.z = q[3]
 
                 current_heading_as_imu = Imu()
                 current_heading_as_imu.header.stamp = current_time
                 current_heading_as_imu.header.frame_id = frame_id
-                current_heading_as_imu.orientation = current_heading._quaternion
+                current_heading_as_imu.orientation = current_heading.quaternion
 
                 self.heading_pub.publish(current_heading)
                 self.heading_imu_pub.publish(current_heading_as_imu)


### PR DESCRIPTION
I think it’s often that people of robotics use this driver with robot_localization package, IMU messages are accepted for state estimation nodes but in the current form heading is only
Published as QuaternionStamped, it’s convenient if the quaternion is just pushed into IMU no ?  