### PR TITLE
Fix GNSS receiver startup bug

### DIFF
--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -156,7 +156,7 @@ def convert_time_rmc(date_str, time_str):
         tuple(float, float): 2-tuple of (NaN, NaN) if the sentence does not contain valid time.
     """
     # If one of the time fields is empty, return NaN seconds
-    if not time_str[0:2] or not time_str[2:4] or not time_str[4:6]:
+    if not date_str[0:6] or not time_str[0:2] or not time_str[2:4] or not time_str[4:6]:
         return (float('NaN'), float('NaN'))
 
     pc_year = datetime.date.today().year


### PR DESCRIPTION
Some receivers first report only time without date during startup making the driver crash when started before the receiver has an initial fully qualified time fix, so including the date. This PR fixes the bug.

As a side effect this also re-runs the Github actions, see https://github.com/ros-drivers/nmea_navsat_driver/pull/136#issuecomment-1074558620

Signed-off-by: Gabriel Gaessler <gabriel.gaessler@de.bosch.com>