### PR TITLE
Extend workflow time and fix debian serial port bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: [ubuntu-latest]
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       matrix:
         ros_distro: [noetic]

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -118,7 +118,9 @@ class TestDriver(unittest.TestCase):
             th_vsp.daemon = True
             th_vsp.start()
 
-        return f.getvalue().split('\n')[:-1]
+        vsp_ret = f.getvalue()
+        rospy.logwarn(vsp_ret)
+        return vsp_ret.split('\n')[:-1]
 
     def playback_log(self, launchfile, log):
         """Playback a logfile."""

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -187,10 +187,11 @@ class TestDriver(unittest.TestCase):
 
         # init serial handler and wait until vsps are ready
         ports = self.create_vsps()
-        self.serial_writer = serial.Serial(ports[0], 115200)
         while len(ports) < 2:
             rospy.logwarn('Virtual serial ports not ready yet, waiting...')
             rospy.sleep(.5)
+
+        self.serial_writer = serial.Serial(ports[0], 115200)
 
         # process all launch files
         for launchfile in self.cfg_launches:

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -122,9 +122,7 @@ class TestDriver(unittest.TestCase):
             rospy.sleep(2.)
 
         while len(ports) < 2:
-            vsp_ret = f.getvalue()
-            rospy.logwarn(vsp_ret)
-            ports = vsp_ret.split('\n')[:-1]
+            ports = f.getvalue().split('\n')[:-1]
 
             if len(ports) < 2:
                 rospy.logwarn('Virtual serial ports not ready yet, waiting...')


### PR DESCRIPTION
Idling for 9 minutes and then counting these 9 minutes against the 10 minutes threshold was by far a new record from what I've seen so far: https://github.com/ros-drivers/nmea_navsat_driver/runs/5672759022?check_suite_focus=true
Therefore extending the limit.

In addition the ROS buildfarm debian builder seems to have an inconsistent behavior concerning the time it takes to open virtual serial ports, causing the build to crash sometimes. This is also fixed here.

Signed-off-by: Gabriel Gaessler <gabriel.gaessler@de.bosch.com>