### PR TITLE
Add Support for TCP GNSS Sensor

### DIFF
--- a/config/nmea_tcpclient_driver.yaml
+++ b/config/nmea_tcpclient_driver.yaml
@@ -1,0 +1,5 @@
+nmea_navsat_driver:
+  ros__parameters:
+    ip: "192.168.131.22"
+    port: 9001
+    buffer_size: 4096

--- a/launch/nmea_serial_driver.launch.py
+++ b/launch/nmea_serial_driver.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/nmea_serial_driver.launch.py
+++ b/launch/nmea_serial_driver.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Open Source Robotics Foundation, Inc.
+# Copyright 2018 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/nmea_socket_driver.launch.py
+++ b/launch/nmea_socket_driver.launch.py
@@ -1,0 +1,55 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" A simple launch file for the nmea_socket_driver node. """
+
+import os
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription, LaunchIntrospector, LaunchService
+from launch_ros import actions
+
+
+def generate_launch_description():
+    """Generate a launch description for a single socket driver."""
+    config_file = os.path.join(get_package_share_directory("nmea_navsat_driver"), "config", "nmea_socket_driver.yaml")
+    driver_node = actions.Node(
+        package='nmea_navsat_driver',
+        executable='nmea_socket_driver',
+        output='screen',
+        parameters=[config_file])
+
+    return LaunchDescription([driver_node])
+
+
+def main(argv):
+    ld = generate_launch_description()
+
+    print('Starting introspection of launch description...')
+    print('')
+
+    print(LaunchIntrospector().format_launch_description(ld))
+
+    print('')
+    print('Starting launch of launch description...')
+    print('')
+
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    return ls.run()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/launch/nmea_socket_driver.launch.py
+++ b/launch/nmea_socket_driver.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/nmea_tcpclient_driver.launch.py
+++ b/launch/nmea_tcpclient_driver.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2022 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch/nmea_tcpclient_driver.launch.py
+++ b/launch/nmea_tcpclient_driver.launch.py
@@ -1,0 +1,55 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" A simple launch file for the nmea_tcpclient_driver node. """
+
+import os
+import sys
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription, LaunchIntrospector, LaunchService
+from launch_ros import actions
+
+
+def generate_launch_description():
+    """Generate a launch description for a single tcpclient driver."""
+    config_file = os.path.join(get_package_share_directory("nmea_navsat_driver"), "config", "nmea_tcpclient_driver.yaml")
+    driver_node = actions.Node(
+        package='nmea_navsat_driver',
+        executable='nmea_tcpclient_driver',
+        output='screen',
+        parameters=[config_file])
+
+    return LaunchDescription([driver_node])
+
+
+def main(argv):
+    ld = generate_launch_description()
+
+    print('Starting introspection of launch description...')
+    print('')
+
+    print(LaunchIntrospector().format_launch_description(ld))
+
+    print('')
+    print('Starting launch of launch description...')
+    print('')
+
+    ls = LaunchService()
+    ls.include_launch_description(ld)
+    return ls.run()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     entry_points={
         'console_scripts': ['nmea_serial_driver = libnmea_navsat_driver.nodes.nmea_serial_driver:main',
                             'nmea_socket_driver = libnmea_navsat_driver.nodes.nmea_socket_driver:main',
+                            'nmea_tcpclient_driver = libnmea_navsat_driver.nodes.nmea_tcpclient_driver:main',
                             'nmea_topic_driver = libnmea_navsat_driver.nodes.nmea_topic_driver:main',
                             'nmea_topic_serial_reader = libnmea_navsat_driver.nodes.nmea_topic_serial_reader:main'],
     }

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -50,6 +50,8 @@ def main(args=None):
 
                 for data in full_lines:
                     try:
+                        data = data.replace('\r', '') # Absoluter Pfusch, aber
+                        data = data.replace('\n', '') # funktioniert halt :D
                         driver.add_sentence(data, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(
@@ -58,6 +60,8 @@ def main(args=None):
                 
                 if last_line.endswith("\n"):
                     try:
+                        last_line = last_line.replace('\r', '') # Absoluter Pfusch, aber
+                        last_line = last_line.replace('\n', '') # funktioniert halt :D
                         driver.add_sentence(last_line, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -45,8 +45,8 @@ def main(args=None):
                 # strip the data
                 data_list = data.decode("ascii").strip().split("\n")
 
-                # remove any messages that are not ended with a newline
-                data_list = [d for d in data_list if d.endswith("\n")]
+                # remove the last element, which is an incomplete message
+                data_list.pop()
 
                 for data in data_list:
                     try:

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -50,7 +50,8 @@ def main(args=None):
 
                 for data in data_list:
                     try:
-                        driver.get_logger().info("Received data: {}".format(data))
+                        if (not data.startswith("$"))
+                            driver.get_logger().info("Received data: {}".format(data))
                         #driver.add_sentence(data, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -50,9 +50,7 @@ def main(args=None):
 
                 for data in full_lines:
                     try:
-                        if (not data.startswith("$")):
-                            driver.get_logger().info("Received data: {}".format(data))
-                        #driver.add_sentence(data, frame_id)
+                        driver.add_sentence(data, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "
@@ -60,9 +58,7 @@ def main(args=None):
                 
                 if last_line.endswith("\n"):
                     try:
-                        if (not last_line.startswith("$")):
-                            driver.get_logger().info("Received data: {}".format(last_line))
-                        #driver.add_sentence(data, frame_id)
+                        driver.add_sentence(last_line, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -40,16 +40,17 @@ def main(args=None):
         # recv-loop: When we're connected, keep receiving stuff until that fails
         while rclpy.ok():
             try:
-                # Receive data from the gnss sensor
-                # Receive only whole lines
-                data = gnss_socket.recv(buffer_size).decode('utf-8').split('\n')
-                # Remove the last empty line
-                data = data[:-1]
-                # Parse the data
+                data = gnss_socket.recv(buffer_size)
 
-                for line in data:
+                # strip the data
+                data_list = data.decode("ascii").strip().split("\n")
+
+                # remove any incomplete messages
+                data_list = [d for d in data_list if d[-1] == '*']
+
+                for data in data_list:
                     try:
-                        driver.add_sentence(line, frame_id)
+                        driver.add_sentence(data, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -60,14 +60,14 @@ def main(args=None):
                 
                 if last_line.endswith("\n"):
                     try:
-                        if (not data.startswith("$")):
-                            driver.get_logger().info("Received data: {}".format(data))
+                        if (not last_line.startswith("$")):
+                            driver.get_logger().info("Received data: {}".format(last_line))
                         #driver.add_sentence(data, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "
                             "Error was: %s. Please report this issue to me. " % e)
-                        partial = ""
+                    partial = ""
                 else:
                     # reset our partial data to this part line
                     partial = last_line

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -41,7 +41,7 @@ def main(args=None):
         partial = ""
         while rclpy.ok():
             try:
-                partial = gnss_socket.recv(buffer_size).decode("ascii")
+                partial += gnss_socket.recv(buffer_size).decode("ascii")
 
                 # strip the data
                 lines = partial.splitlines(keepends=True)

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -52,7 +52,10 @@ def main(args=None):
                     try:
                         data = data.replace('\r', '') # Absoluter Pfusch, aber
                         data = data.replace('\n', '') # funktioniert halt :D
-                        driver.add_sentence(data, frame_id)
+                        if driver.add_sentence(data, frame_id):
+                            driver.get_logger().info("Received sentence: %s" % data)
+                        else:
+                            driver.get_logger().warn("Error with sentence: %s" % data)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "
@@ -62,7 +65,10 @@ def main(args=None):
                     try:
                         last_line = last_line.replace('\r', '') # Absoluter Pfusch, aber
                         last_line = last_line.replace('\n', '') # funktioniert halt :D
-                        driver.add_sentence(last_line, frame_id)
+                        if driver.add_sentence(last_line, frame_id):
+                            driver.get_logger().info("Received sentence: %s" % last_line)
+                        else:
+                            driver.get_logger().warn("Error with sentence: %s" % last_line)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -50,7 +50,8 @@ def main(args=None):
 
                 for data in data_list:
                     try:
-                        driver.add_sentence(data, frame_id)
+                        driver.get_logger().info("Received data: {}".format(data))
+                        #driver.add_sentence(data, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -72,12 +72,6 @@ def main(args=None):
                     # reset our partial data to this part line
                     partial = last_line
 
-        # and reset our partial data to nothing
-        data = ""
-    else:
-        # reset our partial data to this part line
-        data = last_line
-
 
             except socket.error as exc:
                 driver.get_logger().error("Caught exception socket.error when receiving: %s" % exc)

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -40,19 +40,21 @@ def main(args=None):
         # recv-loop: When we're connected, keep receiving stuff until that fails
         while rclpy.ok():
             try:
-                data = gnss_socket.recv(buffer_size)
+                # Receive data from the gnss sensor
+                # Receive only whole lines
+                data = gnss_socket.recv(buffer_size).decode('utf-8').split('\n')
+                # Remove the last empty line
+                data = data[:-1]
+                # Parse the data
 
-                # strip the data
-                data_list = data.decode("ascii").strip().split("\n")
-
-                for data in data_list:
-
+                for line in data:
                     try:
-                        driver.add_sentence(data, frame_id)
+                        driver.add_sentence(line, frame_id)
                     except ValueError as e:
                         driver.get_logger().warn(
                             "Value error, likely due to missing fields in the NMEA message. "
                             "Error was: %s. Please report this issue to me. " % e)
+
 
             except socket.error as exc:
                 driver.get_logger().error("Caught exception socket.error when receiving: %s" % exc)

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -1,0 +1,63 @@
+# Created by Lucas Neuber
+# This is for you, Köter :P
+
+import socket;
+import sys;
+
+import rclpy;
+
+from libnmea_navsat_driver.driver import Ros2NMEADriver;
+
+def main(args=None):
+    rclpy.init(args=args)
+    driver = Ros2NMEADriver()
+
+    try:
+        gnss_ip = driver.declare_parameter('ip', '192.168.131.22').value
+        gnss_port = driver.declare_parameter('port', 9001).value
+        buffer_size = driver.declare_parameter('buffer_size', 4096).value
+    except KeyError as e:
+        driver.get_logger().err("Parameter %s not found" % e)
+        sys.exit(1)
+
+    frame_id = driver.get_frame_id()
+
+    driver.get_logger().info("Using gnss sensor with ip {} and port {}".format(gnss_ip, gnss_port))
+
+    # Connection-loop: connect and keep receiving. If receiving fails, reconnect
+    # Connect to the gnss sensor using tcp
+    while rclpy.ok():
+        try:
+            # Create a socket
+            gnss_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+            # Connect to the gnss sensor
+            gnss_socket.connect((gnss_ip, gnss_port))
+        except socket.error as exc:
+            driver.get_logger().error("Caught exception socket.error when setting up socket: %s" % exc)
+            sys.exit(1)
+
+        # recv-loop: When we're connected, keep receiving stuff until that fails
+        while rclpy.ok():
+            try:
+                data = gnss_socket.recv(buffer_size)
+
+                # strip the data
+                data_list = data.decode("ascii").strip().split("\n")
+
+                for data in data_list:
+
+                    try:
+                        driver.add_sentence(data, frame_id)
+                    except ValueError as e:
+                        driver.get_logger().warn(
+                            "Value error, likely due to missing fields in the NMEA message. "
+                            "Error was: %s. Please report this issue to me. " % e)
+
+            except socket.error as exc:
+                driver.get_logger().error("Caught exception socket.error when receiving: %s" % exc)
+                gnss_socket.close()
+                break
+
+
+        gnss_socket.close()

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -45,8 +45,8 @@ def main(args=None):
                 # strip the data
                 data_list = data.decode("ascii").strip().split("\n")
 
-                # remove any incomplete messages
-                data_list = [d for d in data_list if d[-1] == '*']
+                # remove any messages that are not ended with a newline
+                data_list = [d for d in data_list if d.endswith("\n")]
 
                 for data in data_list:
                     try:

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -45,7 +45,8 @@ def main(args=None):
                 # strip the data
                 data_list = data.decode("ascii").strip().split("\n")
 
-                # remove the last element, which is an incomplete message
+                # remove the first and last element of the list
+                data_list.pop(0)
                 data_list.pop()
 
                 for data in data_list:

--- a/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_tcpclient_driver.py
@@ -50,7 +50,7 @@ def main(args=None):
 
                 for data in data_list:
                     try:
-                        if (not data.startswith("$"))
+                        if (not data.startswith("$")):
                             driver.get_logger().info("Received data: {}".format(data))
                         #driver.add_sentence(data, frame_id)
                     except ValueError as e:


### PR DESCRIPTION
I added a new `nmea_tcpclient_driver`, because Sensors like the `Emlid Reach RS2` do not offer any UDP connection, but transmit NMEA-Sentences on Port 9001/tcp. The `nmea_tcpclient_driver` connects to it via TCP and forwards the NMEA-Sentences line by line to the driver.

*PS: Sorry about the commit-Messages, got a little exhausted during debugging ;)*