### PR TITLE
Fix a bug in the GPS time parsing.

### DIFF
--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -136,7 +136,7 @@ def convert_time(nmea_utc):
     # Resolve the ambiguity of day
     day_offset = int((utc_time.hour - hours)/12.0)
     utc_time += datetime.timedelta(day_offset)
-    utc_time.replace(hour=hours, minute=minutes, second=seconds)
+    utc_time = utc_time.replace(hour=hours, minute=minutes, second=seconds)
 
     unix_secs = calendar.timegm(utc_time.timetuple())
     return (unix_secs, nanosecs)


### PR DESCRIPTION
This causes it to emit incorrect time reference messages if the system time is off the GPS time by more than a second.

The root cause here is that [`datetime.replace`](https://docs.python.org/3/library/datetime.html#datetime.datetime.replace) does *not* modify the `datetime` in-place. Consequently, the time reference will be set to the system time no matter what.