### PR TITLE
Missing return and logger change for ROS2

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -271,6 +271,7 @@ class Ros2NMEADriver(Node):
                 self.heading_pub.publish(current_heading)
         else:
             return False
+        return True
 
     """Helper method for getting the frame_id with the correct TF prefix"""
     def get_frame_id(self):

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -34,9 +34,9 @@ import re
 import time
 import calendar
 import math
-import logging
+import rclpy
 
-logger = logging.getLogger('rosout')
+logger = rclpy.logging.get_logger('nmea_navsat_driver')
 
 
 def safe_float(field):


### PR DESCRIPTION
return True added to driver.add_sentence to avoid that returning None an error message is generated even if the sentence is correctly parsed

logger definition changed for ROS2 compatibility