### PR TITLE
Sentence field must be of type str

### DIFF
--- a/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_topic_serial_reader.py
@@ -60,7 +60,7 @@ def main(args=None):
                 sentence = Sentence()
                 sentence.header.stamp = driver.get_clock().now().to_msg()
                 sentence.header.frame_id = frame_id
-                sentence.sentence = data
+                sentence.sentence = data.decode("ascii")
                 nmea_pub.publish(sentence)
 
         except Exception as e:


### PR DESCRIPTION
In nmea_topic_serial_reader, sentence field is a bytes object and should be a str object.

Fixes: https://github.com/ros-drivers/nmea_navsat_driver/issues/172