### PR TITLE
[bug] Using UDP communication, some statements fail to match because line breaks are not cleanly filtered

### DIFF
--- a/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
@@ -73,15 +73,22 @@ def main(args=None):
             sys.exit(1)
 
         # recv-loop: When we're connected, keep receiving stuff until that fails
+        partial = ""
         while rclpy.ok():
             try:
                 data, remote_address = socket_.recvfrom(buffer_size)
-
+                partial += data.decode("ascii")
+                
                 # strip the data
-                data_list = data.decode("ascii").strip().split("\n")
+                lines = partial.splitlines()
+                if partial.endswith('\n'):
+                    full_lines = lines
+                    partial = ""
+                else:
+                    full_lines = lines[:-1]
+                    partial = lines[-1]
 
-                for data in data_list:
-
+                for data in full_lines:
                     try:
                         driver.add_sentence(data, frame_id)
                     except ValueError as e:

--- a/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_socket_driver.py
@@ -73,22 +73,15 @@ def main(args=None):
             sys.exit(1)
 
         # recv-loop: When we're connected, keep receiving stuff until that fails
-        partial = ""
         while rclpy.ok():
             try:
                 data, remote_address = socket_.recvfrom(buffer_size)
-                partial += data.decode("ascii")
-                
-                # strip the data
-                lines = partial.splitlines()
-                if partial.endswith('\n'):
-                    full_lines = lines
-                    partial = ""
-                else:
-                    full_lines = lines[:-1]
-                    partial = lines[-1]
 
-                for data in full_lines:
+                # strip the data
+                data_list = data.decode("ascii").strip().split()
+
+                for data in data_list:
+
                     try:
                         driver.add_sentence(data, frame_id)
                     except ValueError as e:


### PR DESCRIPTION
Fix the problem： https://github.com/ros-drivers/nmea_navsat_driver/issues/171
It's been tested in real life.

- [x] branch: ros2
- [x] commint:548c84a469bf723ee911d824c33fa50b87106fc1