### PR TITLE
Add support for proprietary PASHR sentence

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -49,6 +49,9 @@ class Ros2NMEADriver(Node):
         self.fix_pub = self.create_publisher(NavSatFix, 'fix', 10)
         self.vel_pub = self.create_publisher(TwistStamped, 'vel', 10)
         self.heading_pub = self.create_publisher(QuaternionStamped, 'heading', 10)
+        # Orientation is relative to ENU (REP 103) in contrast with heading which
+        # is positive clockwise from North
+        self.orientation_pub = self.create_publisher(QuaternionStamped, 'orientation', 10)
 
         self.time_ref_source = self.declare_parameter('time_ref_source', 'gps').value
         self.use_RMC = self.declare_parameter('useRMC', False).value
@@ -276,6 +279,24 @@ class Ros2NMEADriver(Node):
                 current_heading.quaternion.z = q[2]
                 current_heading.quaternion.w = q[3]
                 self.heading_pub.publish(current_heading)
+        elif 'PASHR' in parsed_sentence:
+            data = parsed_sentence['PASHR']
+            if data['roll'] and data['pitch'] and data['heading']:
+                current_orientation = QuaternionStamped()
+                current_orientation.header.stamp = current_time
+                current_orientation.header.frame_id = frame_id
+                # Convert from NED (Tait-Bryan angles) to ENU (quaternion)
+                q = quaternion_from_euler(
+                    math.radians(90.0-data['heading']),
+                    -math.radians(data['pitch']),
+                    math.radians(data['roll']),
+                    'rzyx'
+                )
+                current_orientation.quaternion.x = q[0]
+                current_orientation.quaternion.y = q[1]
+                current_orientation.quaternion.z = q[2]
+                current_orientation.quaternion.w = q[3]
+                self.orientation_pub.publish(current_orientation)
         else:
             return False
         return True

--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -199,6 +199,12 @@ parse_maps = {
     "VTG": [
         ("true_course", convert_deg_to_rads, 1),
         ("speed", convert_knots_to_mps, 5)
+    ],
+    "PASHR": [
+        ("utc_time", convert_time, 1),
+        ("heading", safe_float, 2),
+        ("roll", safe_float, 4),
+        ("pitch", safe_float, 5),
     ]
 }
 
@@ -206,7 +212,7 @@ parse_maps = {
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
 
-    if not re.match(r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+    if not re.match(r'(^\$GP|^\$GN|^\$GL|^\$IN|^\$P).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))
         return False
@@ -214,6 +220,9 @@ def parse_nmea_sentence(nmea_sentence):
 
     # Ignore the $ and talker ID portions (e.g. GP)
     sentence_type = fields[0][3:]
+    # Support proprietary sentences that start with P
+    if fields[0][0:2] == "$P":
+        sentence_type = fields[0][1:]
 
     if sentence_type not in parse_maps:
         logger.debug("Sentence type %s not in parse map, ignoring."


### PR DESCRIPTION
The $PASHR sentense is used by many intergrated motion systems, especially in the marine domain, to report heading, pitch and roll data. 