### PR TITLE
Add missing regex matching for HDT NMEA messages

### DIFF
--- a/src/libnmea_navsat_driver/parser.py
+++ b/src/libnmea_navsat_driver/parser.py
@@ -206,7 +206,7 @@ parse_maps = {
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
 
-    if not re.match(r'(^\$GP|^\$GN|^\$GL|^\$IN).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+    if not re.match(r'(^\$GP|^\$GN|^\$GL|^\$IN|^\$HDT).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))
         return False


### PR DESCRIPTION
There is already parser code to get the heading value if the message was matched by regex. But the regex for matching is missing the HDT message type. This PR is adding this missing type.
Tested and used in ROS1 branch on real NMEA source but never mainlined.
Tested on ROS2 branch and now try to get mainline.